### PR TITLE
Direct input to the correct libvterm API

### DIFF
--- a/lib/src/main/java/org/connectbot/terminal/KeyboardHandler.kt
+++ b/lib/src/main/java/org/connectbot/terminal/KeyboardHandler.kt
@@ -114,10 +114,15 @@ internal class KeyboardHandler(
      * This handles multi-byte UTF-8 text from the software keyboard.
      */
     fun onTextInput(bytes: ByteArray) {
-        if (bytes.isNotEmpty()) {
-            terminalEmulator.writeInput(bytes)
-            modifierManager?.clearTransients()
+        if (bytes.isEmpty()) return
+
+        val modifiers = getModifierMask()
+        val text = bytes.toString(Charsets.UTF_8)
+
+        text.forEach { char ->
+            terminalEmulator.dispatchCharacter(modifiers, char)
         }
+        modifierManager?.clearTransients()
     }
 
     /**


### PR DESCRIPTION
This was writing directly to the emulator which is incorrect. It should write to the keyboard handler that will eventually call the callback for the client to handle the inputs.