### PR TITLE
Disable validation for Maven Central deployment

### DIFF
--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -154,7 +154,7 @@ dokka {
 }
 
 mavenPublishing {
-    publishToMavenCentral(automaticRelease = true)
+    publishToMavenCentral(automaticRelease = true, validateDeployment = false)
     signAllPublications()
 
     coordinates(groupId = "org.connectbot", artifactId = "termlib")


### PR DESCRIPTION
This is taking forever and making builds fail even if the publishing is later finished.