### PR TITLE
Use lazy initialization to avoid "this" leaking

### DIFF
--- a/lib/src/androidTest/java/org/connectbot/terminal/OscSequenceTest.kt
+++ b/lib/src/androidTest/java/org/connectbot/terminal/OscSequenceTest.kt
@@ -19,7 +19,7 @@ package org.connectbot.terminal
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
-import org.junit.Assert.*
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 

--- a/lib/src/androidTest/java/org/connectbot/terminal/ShellIntegrationTest.kt
+++ b/lib/src/androidTest/java/org/connectbot/terminal/ShellIntegrationTest.kt
@@ -2,7 +2,8 @@ package org.connectbot.terminal
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.runBlocking
-import org.junit.Assert.*
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Test
 import org.junit.runner.RunWith
 

--- a/lib/src/main/cpp/Terminal.cpp
+++ b/lib/src/main/cpp/Terminal.cpp
@@ -214,20 +214,9 @@ Terminal::Terminal(JNIEnv* env, jobject callbacks, int rows, int cols)
     // Configure damage merging
     vterm_screen_set_damage_merge(mVts, VTERM_DAMAGE_SCROLL);
 
-    LOGD("Terminal initialized successfully");
-}
-
-void Terminal::reset() {
-    std::lock_guard<std::recursive_mutex> lock(mLock);
-
-    if (!mVts) {
-        LOGE("reset: VTermScreen not initialized");
-        return;
-    }
-
-    // Reset the terminal screen - this will trigger damage callbacks
-    // Safe to call now that the Terminal object is fully constructed
     vterm_screen_reset(mVts, 1);
+
+    LOGD("Terminal initialized successfully");
 }
 
 Terminal::~Terminal() {
@@ -1122,12 +1111,6 @@ Java_org_connectbot_terminal_TerminalNative_nativeSetDefaultColors(JNIEnv* /* en
                                                                    jlong ptr, jint fgColor, jint bgColor) {
     auto* term = reinterpret_cast<Terminal*>(ptr);
     return term->setDefaultColors(static_cast<uint32_t>(fgColor), static_cast<uint32_t>(bgColor));
-}
-
-JNIEXPORT void JNICALL
-Java_org_connectbot_terminal_TerminalNative_nativeReset(JNIEnv* /* env */, jobject /* thiz */, jlong ptr) {
-    auto* term = reinterpret_cast<Terminal*>(ptr);
-    term->reset();
 }
 
 } // extern "C"

--- a/lib/src/main/cpp/Terminal.h
+++ b/lib/src/main/cpp/Terminal.h
@@ -44,9 +44,6 @@ public:
     int setPaletteColors(const uint32_t* colors, int count);
     int setDefaultColors(uint32_t fgColor, uint32_t bgColor);
 
-    // Initialize the terminal screen (must be called after construction)
-    void reset();
-
 private:
     // libvterm screen callbacks (called by libvterm)
     static int termDamage(VTermRect rect, void* user);

--- a/lib/src/main/java/org/connectbot/terminal/TerminalEmulator.kt
+++ b/lib/src/main/java/org/connectbot/terminal/TerminalEmulator.kt
@@ -238,15 +238,14 @@ internal class TerminalEmulatorImpl(
     }
 
     // Native terminal instance - MUST be initialized AFTER damageLock and other state
-    private val terminalNative: TerminalNative = TerminalNative(this)
+    private val terminalNative by lazy {
+        TerminalNative(this).apply {
+            resize(initialRows, initialCols)
+        }
+    }
 
     // Parser for OSC sequences
     private val oscParser = OscParser()
-
-    init {
-        // Initialize terminal with specified dimensions
-        terminalNative.resize(initialRows, initialCols)
-    }
 
     // ================================================================================
     // Public API

--- a/lib/src/main/java/org/connectbot/terminal/TerminalNative.kt
+++ b/lib/src/main/java/org/connectbot/terminal/TerminalNative.kt
@@ -40,9 +40,6 @@ internal class TerminalNative(callbacks: TerminalCallbacks) : AutoCloseable {
         if (nativePtr == 0L) {
             throw RuntimeException("Failed to initialize native terminal")
         }
-        // Reset the terminal after both native and Kotlin objects are fully initialized
-        // This ensures callbacks won't be invoked during construction
-        nativeReset(nativePtr)
     }
 
     /**
@@ -182,7 +179,6 @@ internal class TerminalNative(callbacks: TerminalCallbacks) : AutoCloseable {
     // Native method declarations
     private external fun nativeInit(callbacks: TerminalCallbacks): Long
     private external fun nativeDestroy(ptr: Long): Int
-    private external fun nativeReset(ptr: Long)
     private external fun nativeWriteInputBuffer(ptr: Long, buffer: ByteBuffer, length: Int): Int
     private external fun nativeWriteInputArray(ptr: Long, data: ByteArray, offset: Int, length: Int): Int
     private external fun nativeResize(ptr: Long, rows: Int, cols: Int): Int


### PR DESCRIPTION
JNI can use an object before it is fully initialized when you leak a reference to "this" in the constructor. To avoid racing with damage update in the handler thread, use lazy initialization.