### PR TITLE
Add OSC 52 clipboard support

### DIFF
--- a/lib/api.txt
+++ b/lib/api.txt
@@ -60,7 +60,7 @@ package org.connectbot.terminal {
   }
 
   public static final class TerminalEmulatorFactory.Companion {
-    method public org.connectbot.terminal.TerminalEmulator create(optional android.os.Looper looper, optional int initialRows, optional int initialCols, optional long defaultForeground, optional long defaultBackground, optional kotlin.jvm.functions.Function1<? super byte[],kotlin.Unit> onKeyboardInput, optional kotlin.jvm.functions.Function0<kotlin.Unit>? onBell, optional kotlin.jvm.functions.Function1<? super org.connectbot.terminal.TerminalDimensions,kotlin.Unit>? onResize);
+    method public org.connectbot.terminal.TerminalEmulator create(optional android.os.Looper looper, optional int initialRows, optional int initialCols, optional long defaultForeground, optional long defaultBackground, optional kotlin.jvm.functions.Function1<? super byte[],kotlin.Unit> onKeyboardInput, optional kotlin.jvm.functions.Function0<kotlin.Unit>? onBell, optional kotlin.jvm.functions.Function1<? super org.connectbot.terminal.TerminalDimensions,kotlin.Unit>? onResize, optional kotlin.jvm.functions.Function1<? super java.lang.String,kotlin.Unit>? onClipboardCopy);
   }
 
   public final class TerminalKt {

--- a/lib/src/main/java/org/connectbot/terminal/OscParser.kt
+++ b/lib/src/main/java/org/connectbot/terminal/OscParser.kt
@@ -98,7 +98,7 @@ internal class OscParser {
 
         // Decode base64 data
         val decodedData = try {
-            String(java.util.Base64.getDecoder().decode(base64Data), Charsets.UTF_8)
+            kotlin.io.encoding.Base64.Default.decode(base64Data).toString(Charsets.UTF_8)
         } catch (e: IllegalArgumentException) {
             // Invalid base64 data
             return emptyList()

--- a/lib/src/main/java/org/connectbot/terminal/OscParser.kt
+++ b/lib/src/main/java/org/connectbot/terminal/OscParser.kt
@@ -16,6 +16,8 @@
  */
 package org.connectbot.terminal
 
+import kotlin.io.encoding.Base64;
+
 /**
  * Parser for OSC (Operating System Command) sequences.
  * Handles clipboard operations (OSC 52), shell integration (OSC 133),
@@ -98,7 +100,7 @@ internal class OscParser {
 
         // Decode base64 data
         val decodedData = try {
-            kotlin.io.encoding.Base64.Default.decode(base64Data).toString(Charsets.UTF_8)
+            Base64.Default.decode(base64Data).toString(Charsets.UTF_8)
         } catch (e: IllegalArgumentException) {
             // Invalid base64 data
             return emptyList()


### PR DESCRIPTION
Fix #34 and is required for connectbot/connectbot#1570. 

Implement OSC 52 escape sequence handling to allow terminal applications to write data to the system clipboard. This enables features like copying text from remote sessions using tools like tmux or vim.

Changes:
- Add ClipboardCopy action to OscParser for OSC 52 sequences
- Add onClipboardCopy callback parameter to TerminalEmulatorFactory
- Handle clipboard copy actions in TerminalEmulatorImpl
- Add comprehensive unit tests for OSC 52 parsing

Security: Clipboard read requests (Pd = "?") are rejected to prevent potential clipboard data exfiltration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)