### PR TITLE
Fix OSC 52 clipboard support using VTermSelectionCallbacks

### DIFF
--- a/lib/src/main/cpp/Terminal.h
+++ b/lib/src/main/cpp/Terminal.h
@@ -60,6 +60,10 @@ private:
     // libvterm state fallback for OSC sequences
     static int termOscFallback(int command, VTermStringFragment frag, void* user);
 
+    // libvterm selection callbacks for OSC 52 clipboard
+    static int termSelectionSet(VTermSelectionMask mask, VTermStringFragment frag, void* user);
+    static int termSelectionQuery(VTermSelectionMask mask, void* user);
+
     // Java callback invocation helpers
     void invokeDamage(int startRow, int endRow, int startCol, int endCol);
     int invokeMoverect(VTermRect dest, VTermRect src);
@@ -80,6 +84,12 @@ private:
     VTermScreen* mVts;
     VTermScreenCallbacks mScreenCallbacks{};
     VTermStateFallbacks mStateFallbacks{};
+    VTermSelectionCallbacks mSelectionCallbacks{};
+
+    // Selection buffer for OSC 52 clipboard (libvterm uses this for base64 decoding)
+    static constexpr size_t SELECTION_BUFFER_SIZE = 8192;
+    char mSelectionBuffer[SELECTION_BUFFER_SIZE]{};
+    std::string mSelectionData;  // Accumulates decoded clipboard data across fragments
 
     // Terminal dimensions
     int mRows;

--- a/lib/src/test/java/org/connectbot/terminal/OscParserTest.kt
+++ b/lib/src/test/java/org/connectbot/terminal/OscParserTest.kt
@@ -149,14 +149,18 @@ class OscParserTest {
     }
 
     @Test
-    fun testOsc52InvalidBase64() {
+    fun testOsc52InvalidBase64TreatedAsRawData() {
         val parser = OscParser()
         val row = 0
         val cols = 80
 
-        // Invalid base64 data
+        // Invalid base64 data is treated as raw/pre-decoded data
+        // (libvterm's selection callback provides pre-decoded data)
         val actions = parser.parse(52, "c;!!invalid!!", row, 0, cols)
-        assertTrue(actions.isEmpty())
+        assertEquals(1, actions.size)
+        val action = actions[0] as OscParser.Action.ClipboardCopy
+        assertEquals("c", action.selection)
+        assertEquals("!!invalid!!", action.data)
     }
 
     @Test


### PR DESCRIPTION
I apologize that #45 was not enough to implement https://github.com/connectbot/connectbot/issues/1570. This PR fixes that. 

The OSC 52 clipboard functionality was not working because libvterm handles OSC 52 internally using VTermSelectionCallbacks, not the fallback mechanism. Since libvterm recognizes OSC 52, it never called the unrecognised_fallbacks handler.

Changes:
- Add VTermSelectionCallbacks with termSelectionSet and termSelectionQuery
- Register selection callbacks using vterm_state_set_selection_callbacks()
- Add selection buffer for libvterm's base64 decoding
- Update OscParser to handle both base64-encoded and pre-decoded data (libvterm's selection callback provides pre-decoded data)
- Update tests to reflect new behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)