### PR TITLE
Include debug symbols in release build

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,6 +6,6 @@ android.enableJetifier=false
 android.jetifier.ignorelist=bcprov-jdk15on
 org.gradle.configuration-cache=true
 
-version=0.0.13-SNAPSHOT
+version=0.0.14-SNAPSHOT
 group=org.connectbot
 description=ConnetBot's Terminal Emulator library

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -27,6 +27,7 @@ android {
 
         ndk {
             abiFilters += listOf("armeabi-v7a", "arm64-v8a", "x86", "x86_64")
+            debugSymbolLevel = "full"
         }
     }
 
@@ -58,6 +59,12 @@ android {
 
     composeOptions {
         kotlinCompilerExtensionVersion = "1.5.3"
+    }
+
+    packaging {
+        jniLibs {
+            keepDebugSymbols.add("**/*.so")
+        }
     }
 }
 


### PR DESCRIPTION
This will help with crashes that happen in the debug part of this libary.