### PR TITLE
Fix copy/paste including spurious newlines and whitespace

### DIFF
--- a/lib/src/main/cpp/Terminal.h
+++ b/lib/src/main/cpp/Terminal.h
@@ -40,6 +40,9 @@ public:
     // Cell data retrieval for rendering
     int getCellRun(JNIEnv* env, int row, int col, jobject runObject);
 
+    // Line info retrieval (for continuation/soft-wrap detection)
+    bool getLineContinuation(int row);
+
     // Color configuration
     int setPaletteColors(const uint32_t* colors, int count);
     int setDefaultColors(uint32_t fgColor, uint32_t bgColor);
@@ -70,7 +73,7 @@ private:
     void invokeMoveCursor(int row, int col, int oldRow, int oldCol, bool visible);
     void invokeSetTermProp(VTermProp prop, VTermValue* val);
     void invokeBell();
-    void invokePushScrollbackLine(int cols, const VTermScreenCell* cells);
+    void invokePushScrollbackLine(int cols, const VTermScreenCell* cells, bool softWrapped);
     int invokePopScrollbackLine(int cols, VTermScreenCell* cells);
     void invokeKeyboardOutput(const char* data, size_t len);
     int invokeOscSequence(int command, const std::string& payload, int cursorRow, int cursorCol);

--- a/lib/src/main/java/org/connectbot/terminal/TerminalCallbacks.kt
+++ b/lib/src/main/java/org/connectbot/terminal/TerminalCallbacks.kt
@@ -76,9 +76,13 @@ internal interface TerminalCallbacks {
      *
      * @param cols Number of columns in the line
      * @param cells Array of screen cells
+     * @param softWrapped True if this line ended with a soft wrap (visual line break due to
+     *                    terminal width), false if it ended with a hard break (actual newline).
+     *                    This is used when copying text to avoid inserting spurious newlines
+     *                    in wrapped long commands.
      * @return 0 on success
      */
-    fun pushScrollbackLine(cols: Int, cells: Array<ScreenCell>): Int
+    fun pushScrollbackLine(cols: Int, cells: Array<ScreenCell>, softWrapped: Boolean): Int
 
     /**
      * Called when a line should be popped from scrollback buffer.

--- a/lib/src/main/java/org/connectbot/terminal/TerminalEmulator.kt
+++ b/lib/src/main/java/org/connectbot/terminal/TerminalEmulator.kt
@@ -494,7 +494,7 @@ internal class TerminalEmulatorImpl(
         return 0
     }
 
-    override fun pushScrollbackLine(cols: Int, cells: Array<ScreenCell>): Int {
+    override fun pushScrollbackLine(cols: Int, cells: Array<ScreenCell>, softWrapped: Boolean): Int {
         // Convert ScreenCell array to TerminalLine
         val cellList = cells.take(cols).map { screenCell ->
             TerminalLine.Cell(
@@ -520,7 +520,7 @@ internal class TerminalEmulatorImpl(
                 emptyList()
             }
 
-            val line = TerminalLine(row = -1, cells = cellList, semanticSegments = line0Segments)
+            val line = TerminalLine(row = -1, cells = cellList, softWrapped = softWrapped, semanticSegments = line0Segments)
 
             scrollback.add(line)
             if (scrollback.size > maxScrollbackLines) {
@@ -838,12 +838,21 @@ internal class TerminalEmulatorImpl(
             col += cellsInRun
         }
 
+        // Check if this line is soft-wrapped (the next line is a continuation).
+        // A line is soft-wrapped if the next row has continuation=true.
+        val softWrapped = if (row + 1 < rows) {
+            terminalNative.getLineContinuation(row + 1)
+        } else {
+            // Last visible row - we can't know if it's wrapped until it scrolls
+            false
+        }
+
         // Update cached line, preserving any existing semantic segments
         // Must synchronize to ensure visibility of segments added by addSemanticSegment
         synchronized(damageLock) {
             currentLines = currentLines.toMutableList().apply {
                 val existingSegments = this[row].semanticSegments
-                this[row] = TerminalLine(row, cells, semanticSegments = existingSegments)
+                this[row] = TerminalLine(row, cells, softWrapped = softWrapped, semanticSegments = existingSegments)
             }
         }
     }

--- a/lib/src/main/java/org/connectbot/terminal/TerminalLine.kt
+++ b/lib/src/main/java/org/connectbot/terminal/TerminalLine.kt
@@ -28,7 +28,16 @@ internal data class TerminalLine(
     val row: Int,
     val cells: List<Cell>,
     val lastModified: Long = System.nanoTime(),
-    val semanticSegments: List<SemanticSegment> = emptyList()
+    val semanticSegments: List<SemanticSegment> = emptyList(),
+    /**
+     * True if this line ended with a soft wrap (visual line break due to terminal width),
+     * false if it ended with a hard break (actual newline character).
+     *
+     * This is used when copying text to avoid inserting spurious newlines in wrapped
+     * long commands. For example, a command like "echo foo bar baz..." that wraps to
+     * multiple lines should be copied as a single line without embedded newlines.
+     */
+    val softWrapped: Boolean = false
 ) {
     /**
      * Get the text content of this line as a string.
@@ -115,7 +124,8 @@ internal data class TerminalLine(
                         fgColor = defaultFg,
                         bgColor = defaultBg
                     )
-                }
+                },
+                softWrapped = false
             )
         }
     }

--- a/lib/src/main/java/org/connectbot/terminal/TerminalNative.kt
+++ b/lib/src/main/java/org/connectbot/terminal/TerminalNative.kt
@@ -154,6 +154,20 @@ internal class TerminalNative(callbacks: TerminalCallbacks) : AutoCloseable {
     }
 
     /**
+     * Get the continuation (soft wrap) status for a visible screen line.
+     *
+     * A line is a "continuation" if it continues from the previous line due to
+     * text wrapping, rather than starting after a hard newline.
+     *
+     * @param row Row index (0-based)
+     * @return true if this line is a continuation of the previous line
+     */
+    fun getLineContinuation(row: Int): Boolean {
+        checkNotClosed()
+        return nativeGetLineContinuation(nativePtr, row)
+    }
+
+    /**
      * Close the terminal and release native resources.
      * After calling this, the Terminal instance cannot be used.
      */
@@ -187,6 +201,7 @@ internal class TerminalNative(callbacks: TerminalCallbacks) : AutoCloseable {
     private external fun nativeGetCellRun(ptr: Long, row: Int, col: Int, run: CellRun): Int
     private external fun nativeSetPaletteColors(ptr: Long, colors: IntArray, count: Int): Int
     private external fun nativeSetDefaultColors(ptr: Long, fgColor: Int, bgColor: Int): Int
+    private external fun nativeGetLineContinuation(ptr: Long, row: Int): Boolean
 
     companion object {
         init {


### PR DESCRIPTION
Fixes connectbot/connectbot#1555

When copying text that spans multiple terminal lines, the selection logic would insert newlines at every visual line boundary, even for lines that wrapped due to terminal width (soft wraps). This caused long commands to break when pasted back. This PR also removes trailing whitespace from each line to ensure the copy matches the original.

Changes:
- Add softWrapped field to TerminalLine to track soft vs hard line breaks
- Expose libvterm's continuation flag via getLineContinuation() JNI method
- Pass softWrapped status when pushing lines to scrollback
- Update SelectionManager to only insert newlines for hard breaks
- Trim trailing whitespace from each line when copying (terminal lines are padded with spaces to fill the terminal width)

🤖 Generated with [Claude Code](https://claude.com/claude-code)