### PR TITLE
Update Dokka to 2.2.0-Beta for AGP 9.0 compatibility

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ spotless = "8.1.0"
 publish = "0.35.0"
 release = "3.1.0"
 metalava = "0.4.0-alpha03"
-dokka = "2.1.0"
+dokka = "2.2.0-Beta"
 
 composeBom = "2025.12.01"
 lifecycleViewModel = "2.10.0"


### PR DESCRIPTION
Dokka 2.1.0 couldn't detect Android source sets with AGP 9.0's built-in Kotlin support, resulting in empty documentation output. Dokka 2.2.0-Beta has proper support for AGP 9.0.
https://github.com/Kotlin/dokka/releases/tag/v2.2.0-Beta