### PR TITLE
OSC 133 support

### DIFF
--- a/lib/api.txt
+++ b/lib/api.txt
@@ -57,6 +57,7 @@ package org.connectbot.terminal {
     method public void dispatchCharacter(int modifiers, char character);
     method public void dispatchKey(int modifiers, int key);
     method public org.connectbot.terminal.TerminalDimensions getDimensions();
+    method public String? getLastCommandOutput();
     method public void resize(int newRows, int newCols);
     method public int setAnsiPalette(int[] ansiColors);
     method public int setDefaultColors(int foreground, int background);

--- a/lib/api.txt
+++ b/lib/api.txt
@@ -1,6 +1,15 @@
 // Signature format: 4.0
 package org.connectbot.terminal {
 
+  public interface ComposeController {
+    method public String getComposedText();
+    method public boolean isComposeModeActive();
+    method public void startComposeMode();
+    method public void stopComposeMode();
+    method public void toggleComposeMode();
+    property public abstract boolean isComposeModeActive;
+  }
+
   public interface ModifierManager {
     method public void clearTransients();
     method public boolean isAltActive();
@@ -76,8 +85,8 @@ package org.connectbot.terminal {
   }
 
   public final class TerminalKt {
-    method public static void Terminal(org.connectbot.terminal.TerminalEmulator terminalEmulator, optional error.NonExistentClass modifier, optional error.NonExistentClass typeface, optional error.NonExistentClass initialFontSize, optional error.NonExistentClass minFontSize, optional error.NonExistentClass maxFontSize, optional error.NonExistentClass backgroundColor, optional error.NonExistentClass foregroundColor, optional boolean keyboardEnabled, optional boolean showSoftKeyboard, optional error.NonExistentClass focusRequester, optional kotlin.jvm.functions.Function0<kotlin.Unit> onTerminalTap, optional kotlin.jvm.functions.Function1<? super java.lang.Boolean,kotlin.Unit> onImeVisibilityChanged, optional error.NonExistentClass? forcedSize, optional org.connectbot.terminal.ModifierManager? modifierManager, optional kotlin.jvm.functions.Function1<? super org.connectbot.terminal.SelectionController,kotlin.Unit>? onSelectionControllerAvailable, optional kotlin.jvm.functions.Function1<? super java.lang.String,kotlin.Unit> onHyperlinkClick);
-    method public static void TerminalWithAccessibility(org.connectbot.terminal.TerminalEmulator terminalEmulator, optional error.NonExistentClass modifier, optional error.NonExistentClass typeface, optional error.NonExistentClass initialFontSize, optional error.NonExistentClass minFontSize, optional error.NonExistentClass maxFontSize, optional error.NonExistentClass backgroundColor, optional error.NonExistentClass foregroundColor, optional boolean keyboardEnabled, optional boolean showSoftKeyboard, optional error.NonExistentClass focusRequester, optional kotlin.jvm.functions.Function0<kotlin.Unit> onTerminalTap, optional kotlin.jvm.functions.Function1<? super java.lang.Boolean,kotlin.Unit> onImeVisibilityChanged, optional error.NonExistentClass? forcedSize, optional org.connectbot.terminal.ModifierManager? modifierManager, optional Boolean? forceAccessibilityEnabled, optional kotlin.jvm.functions.Function1<? super org.connectbot.terminal.SelectionController,kotlin.Unit>? onSelectionControllerAvailable, optional kotlin.jvm.functions.Function1<? super java.lang.String,kotlin.Unit> onHyperlinkClick);
+    method public static void Terminal(org.connectbot.terminal.TerminalEmulator terminalEmulator, optional error.NonExistentClass modifier, optional error.NonExistentClass typeface, optional error.NonExistentClass initialFontSize, optional error.NonExistentClass minFontSize, optional error.NonExistentClass maxFontSize, optional error.NonExistentClass backgroundColor, optional error.NonExistentClass foregroundColor, optional boolean keyboardEnabled, optional boolean showSoftKeyboard, optional error.NonExistentClass focusRequester, optional kotlin.jvm.functions.Function0<kotlin.Unit> onTerminalTap, optional kotlin.jvm.functions.Function1<? super java.lang.Boolean,kotlin.Unit> onImeVisibilityChanged, optional error.NonExistentClass? forcedSize, optional org.connectbot.terminal.ModifierManager? modifierManager, optional kotlin.jvm.functions.Function1<? super org.connectbot.terminal.SelectionController,kotlin.Unit>? onSelectionControllerAvailable, optional kotlin.jvm.functions.Function1<? super java.lang.String,kotlin.Unit> onHyperlinkClick, optional kotlin.jvm.functions.Function1<? super org.connectbot.terminal.ComposeController,kotlin.Unit>? onComposeControllerAvailable);
+    method public static void TerminalWithAccessibility(org.connectbot.terminal.TerminalEmulator terminalEmulator, optional error.NonExistentClass modifier, optional error.NonExistentClass typeface, optional error.NonExistentClass initialFontSize, optional error.NonExistentClass minFontSize, optional error.NonExistentClass maxFontSize, optional error.NonExistentClass backgroundColor, optional error.NonExistentClass foregroundColor, optional boolean keyboardEnabled, optional boolean showSoftKeyboard, optional error.NonExistentClass focusRequester, optional kotlin.jvm.functions.Function0<kotlin.Unit> onTerminalTap, optional kotlin.jvm.functions.Function1<? super java.lang.Boolean,kotlin.Unit> onImeVisibilityChanged, optional error.NonExistentClass? forcedSize, optional org.connectbot.terminal.ModifierManager? modifierManager, optional Boolean? forceAccessibilityEnabled, optional kotlin.jvm.functions.Function1<? super org.connectbot.terminal.SelectionController,kotlin.Unit>? onSelectionControllerAvailable, optional kotlin.jvm.functions.Function1<? super java.lang.String,kotlin.Unit> onHyperlinkClick, optional kotlin.jvm.functions.Function1<? super org.connectbot.terminal.ComposeController,kotlin.Unit>? onComposeControllerAvailable);
   }
 
   public final class VTermKey {

--- a/lib/src/androidTest/java/org/connectbot/terminal/ShellIntegrationTest.kt
+++ b/lib/src/androidTest/java/org/connectbot/terminal/ShellIntegrationTest.kt
@@ -47,9 +47,8 @@ class ShellIntegrationTest {
         assertNotNull("Expected a line marked as PROMPT", promptLine)
 
         // Verify specific segment
-        val segments = promptLine!!.semanticSegments
+        val segments = promptLine!!.getSegmentsOfType(SemanticType.PROMPT)
         assertEquals(1, segments.size)
-        assertEquals(SemanticType.PROMPT, segments[0].semanticType)
         assertEquals(0, segments[0].startCol)
         assertEquals(promptText.length, segments[0].endCol)
     }

--- a/lib/src/main/java/org/connectbot/terminal/AccessibilityOverlay.kt
+++ b/lib/src/main/java/org/connectbot/terminal/AccessibilityOverlay.kt
@@ -137,6 +137,7 @@ internal fun AccessibilityOverlay(
                             add(CustomAccessibilityAction("Read Last Output") {
                                 val outputText = getLastCommandOutput(allLines)
                                 if (outputText != null) {
+                                    @Suppress("DEPRECATION")
                                     view.announceForAccessibility(outputText)
                                     true
                                 } else {

--- a/lib/src/main/java/org/connectbot/terminal/ComposeController.kt
+++ b/lib/src/main/java/org/connectbot/terminal/ComposeController.kt
@@ -1,0 +1,50 @@
+/*
+ * ConnectBot Terminal
+ * Copyright 2025 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.connectbot.terminal
+
+/**
+ * Public API interface for controlling compose mode in the terminal.
+ *
+ * Compose mode buffers typed text locally and displays it as an overlay
+ * at the cursor position. Enter commits the text; Escape cancels.
+ */
+interface ComposeController {
+    /**
+     * Whether compose mode is currently active.
+     */
+    val isComposeModeActive: Boolean
+
+    /**
+     * Start compose mode. Clears any active selection first.
+     */
+    fun startComposeMode()
+
+    /**
+     * Stop compose mode, discarding any buffered text.
+     */
+    fun stopComposeMode()
+
+    /**
+     * Toggle compose mode on/off.
+     */
+    fun toggleComposeMode()
+
+    /**
+     * Get the currently composed (buffered) text.
+     */
+    fun getComposedText(): String
+}

--- a/lib/src/main/java/org/connectbot/terminal/ComposeMode.kt
+++ b/lib/src/main/java/org/connectbot/terminal/ComposeMode.kt
@@ -1,0 +1,79 @@
+/*
+ * ConnectBot Terminal
+ * Copyright 2025 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.connectbot.terminal
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+
+/**
+ * Internal state class for compose mode buffered text input.
+ *
+ * When compose mode is active, typed text is buffered locally and displayed
+ * as an overlay at the cursor position. Enter commits the text; Escape cancels.
+ * This gives safe, typo-friendly text entry.
+ */
+internal class ComposeMode {
+    var isActive by mutableStateOf(false)
+        private set
+
+    var buffer by mutableStateOf("")
+        private set
+
+    fun activate() {
+        buffer = ""
+        isActive = true
+    }
+
+    fun deactivate() {
+        buffer = ""
+        isActive = false
+    }
+
+    fun appendChar(char: Char) {
+        if (!isActive) return
+        buffer += char
+    }
+
+    fun appendText(text: String) {
+        if (!isActive) return
+        buffer += text
+    }
+
+    fun deleteLastChar() {
+        if (!isActive || buffer.isEmpty()) return
+        buffer = buffer.dropLast(1)
+    }
+
+    /**
+     * Commit the composed text. Returns the buffer text and deactivates compose mode.
+     * Returns null if inactive or buffer is empty.
+     */
+    fun commit(): String? {
+        if (!isActive || buffer.isEmpty()) {
+            deactivate()
+            return null
+        }
+        val text = buffer
+        deactivate()
+        return text
+    }
+
+    fun cancel() {
+        deactivate()
+    }
+}

--- a/lib/src/main/java/org/connectbot/terminal/TerminalEmulator.kt
+++ b/lib/src/main/java/org/connectbot/terminal/TerminalEmulator.kt
@@ -104,6 +104,17 @@ sealed interface TerminalEmulator {
     )
 
     val dimensions: TerminalDimensions
+
+    /**
+     * Get the text output of the last completed command.
+     *
+     * Uses OSC 133 semantic segments to find the boundaries of the most recent
+     * completed command output. Requires shell integration (OSC 133) to be
+     * enabled in the user's shell.
+     *
+     * @return The command output text, or null if no completed command is found
+     */
+    fun getLastCommandOutput(): String?
 }
 
 class TerminalEmulatorFactory {
@@ -338,6 +349,15 @@ internal class TerminalEmulatorImpl(
      * Clears the terminal emulator screen.
      */
     override fun clearScreen() = writeInput("\u001B[2J\u001B[H".toByteArray())
+
+    /**
+     * Get the text output of the last completed command.
+     */
+    override fun getLastCommandOutput(): String? {
+        val currentSnapshot = _snapshot.value
+        val allLines = currentSnapshot.scrollback + currentSnapshot.lines
+        return getLastCommandOutput(allLines)
+    }
 
     /**
      * Set ANSI palette colors (indices 0-15).

--- a/lib/src/test/java/org/connectbot/terminal/ComposeModeTest.kt
+++ b/lib/src/test/java/org/connectbot/terminal/ComposeModeTest.kt
@@ -1,0 +1,204 @@
+/*
+ * ConnectBot Terminal
+ * Copyright 2025 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.connectbot.terminal
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class ComposeModeTest {
+    private lateinit var composeMode: ComposeMode
+
+    @Before
+    fun setup() {
+        composeMode = ComposeMode()
+    }
+
+    @Test
+    fun testInitialState() {
+        assertFalse(composeMode.isActive)
+        assertEquals("", composeMode.buffer)
+    }
+
+    @Test
+    fun testActivate() {
+        composeMode.activate()
+        assertTrue(composeMode.isActive)
+        assertEquals("", composeMode.buffer)
+    }
+
+    @Test
+    fun testActivateClearsPreviousBuffer() {
+        composeMode.activate()
+        composeMode.appendChar('a')
+        composeMode.appendChar('b')
+        assertEquals("ab", composeMode.buffer)
+
+        composeMode.activate()
+        assertTrue(composeMode.isActive)
+        assertEquals("", composeMode.buffer)
+    }
+
+    @Test
+    fun testDeactivate() {
+        composeMode.activate()
+        composeMode.appendChar('x')
+        composeMode.deactivate()
+
+        assertFalse(composeMode.isActive)
+        assertEquals("", composeMode.buffer)
+    }
+
+    @Test
+    fun testAppendChar() {
+        composeMode.activate()
+        composeMode.appendChar('h')
+        composeMode.appendChar('i')
+        assertEquals("hi", composeMode.buffer)
+    }
+
+    @Test
+    fun testAppendCharWhenInactive() {
+        composeMode.appendChar('x')
+        assertEquals("", composeMode.buffer)
+    }
+
+    @Test
+    fun testAppendText() {
+        composeMode.activate()
+        composeMode.appendText("hello")
+        assertEquals("hello", composeMode.buffer)
+    }
+
+    @Test
+    fun testAppendTextWhenInactive() {
+        composeMode.appendText("hello")
+        assertEquals("", composeMode.buffer)
+    }
+
+    @Test
+    fun testAppendTextMultiple() {
+        composeMode.activate()
+        composeMode.appendText("hel")
+        composeMode.appendText("lo")
+        assertEquals("hello", composeMode.buffer)
+    }
+
+    @Test
+    fun testDeleteLastChar() {
+        composeMode.activate()
+        composeMode.appendText("abc")
+        composeMode.deleteLastChar()
+        assertEquals("ab", composeMode.buffer)
+    }
+
+    @Test
+    fun testDeleteLastCharEmptyBuffer() {
+        composeMode.activate()
+        composeMode.deleteLastChar()
+        assertEquals("", composeMode.buffer)
+        assertTrue(composeMode.isActive)
+    }
+
+    @Test
+    fun testDeleteLastCharWhenInactive() {
+        composeMode.deleteLastChar()
+        assertEquals("", composeMode.buffer)
+    }
+
+    @Test
+    fun testDeleteAllChars() {
+        composeMode.activate()
+        composeMode.appendText("ab")
+        composeMode.deleteLastChar()
+        composeMode.deleteLastChar()
+        assertEquals("", composeMode.buffer)
+        assertTrue(composeMode.isActive)
+    }
+
+    @Test
+    fun testCommit() {
+        composeMode.activate()
+        composeMode.appendText("hello")
+        val result = composeMode.commit()
+
+        assertEquals("hello", result)
+        assertFalse(composeMode.isActive)
+        assertEquals("", composeMode.buffer)
+    }
+
+    @Test
+    fun testCommitEmptyBuffer() {
+        composeMode.activate()
+        val result = composeMode.commit()
+
+        assertNull(result)
+        assertFalse(composeMode.isActive)
+    }
+
+    @Test
+    fun testCommitWhenInactive() {
+        val result = composeMode.commit()
+
+        assertNull(result)
+        assertFalse(composeMode.isActive)
+    }
+
+    @Test
+    fun testCancel() {
+        composeMode.activate()
+        composeMode.appendText("hello")
+        composeMode.cancel()
+
+        assertFalse(composeMode.isActive)
+        assertEquals("", composeMode.buffer)
+    }
+
+    @Test
+    fun testCancelWhenInactive() {
+        composeMode.cancel()
+        assertFalse(composeMode.isActive)
+        assertEquals("", composeMode.buffer)
+    }
+
+    @Test
+    fun testMixedAppendAndDelete() {
+        composeMode.activate()
+        composeMode.appendChar('a')
+        composeMode.appendChar('b')
+        composeMode.appendChar('c')
+        composeMode.deleteLastChar()
+        composeMode.appendChar('d')
+        assertEquals("abd", composeMode.buffer)
+    }
+
+    @Test
+    fun testCommitThenReactivate() {
+        composeMode.activate()
+        composeMode.appendText("first")
+        composeMode.commit()
+
+        composeMode.activate()
+        composeMode.appendText("second")
+        val result = composeMode.commit()
+
+        assertEquals("second", result)
+    }
+}

--- a/lib/src/test/java/org/connectbot/terminal/ReadLastOutputTest.kt
+++ b/lib/src/test/java/org/connectbot/terminal/ReadLastOutputTest.kt
@@ -1,0 +1,215 @@
+/*
+ * ConnectBot Terminal
+ * Copyright 2025 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.connectbot.terminal
+
+import androidx.compose.ui.graphics.Color
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ReadLastOutputTest {
+    @Test
+    fun testBasicCommandOutput() {
+        // Simulates: prompt$ ls\nfile1\nfile2\n[finished]
+        val lines = listOf(
+            makeLine(0, "prompt\$ ls", listOf(
+                SemanticSegment(0, 8, SemanticType.PROMPT, promptId = 1),
+                SemanticSegment(8, 10, SemanticType.COMMAND_INPUT, promptId = 1)
+            )),
+            makeLine(1, "file1"),
+            makeLine(2, "file2"),
+            makeLine(3, "", listOf(
+                SemanticSegment(0, 0, SemanticType.COMMAND_FINISHED, metadata = "0", promptId = 1)
+            ))
+        )
+
+        val output = getLastCommandOutput(lines)
+        assertNotNull(output)
+        assertEquals("file1\nfile2", output)
+    }
+
+    @Test
+    fun testNoCommandFinished() {
+        val lines = listOf(
+            makeLine(0, "prompt\$ ls", listOf(
+                SemanticSegment(0, 8, SemanticType.PROMPT, promptId = 1),
+                SemanticSegment(8, 10, SemanticType.COMMAND_INPUT, promptId = 1)
+            )),
+            makeLine(1, "file1")
+        )
+
+        assertNull(getLastCommandOutput(lines))
+    }
+
+    @Test
+    fun testNoCommandInput() {
+        val lines = listOf(
+            makeLine(0, "some text"),
+            makeLine(1, "", listOf(
+                SemanticSegment(0, 0, SemanticType.COMMAND_FINISHED, metadata = "0", promptId = 1)
+            ))
+        )
+
+        assertNull(getLastCommandOutput(lines))
+    }
+
+    @Test
+    fun testEmptyOutput() {
+        // Command that produces no output (e.g., "cd /tmp")
+        val lines = listOf(
+            makeLine(0, "prompt\$ cd /tmp", listOf(
+                SemanticSegment(0, 8, SemanticType.PROMPT, promptId = 1),
+                SemanticSegment(8, 15, SemanticType.COMMAND_INPUT, promptId = 1)
+            )),
+            makeLine(1, "", listOf(
+                SemanticSegment(0, 0, SemanticType.COMMAND_FINISHED, metadata = "0", promptId = 1)
+            ))
+        )
+
+        assertNull(getLastCommandOutput(lines))
+    }
+
+    @Test
+    fun testMultipleCommands() {
+        // Two commands: first outputs "hello", second outputs "world"
+        val lines = listOf(
+            makeLine(0, "prompt\$ echo hello", listOf(
+                SemanticSegment(0, 8, SemanticType.PROMPT, promptId = 1),
+                SemanticSegment(8, 18, SemanticType.COMMAND_INPUT, promptId = 1)
+            )),
+            makeLine(1, "hello"),
+            makeLine(2, "", listOf(
+                SemanticSegment(0, 0, SemanticType.COMMAND_FINISHED, metadata = "0", promptId = 1)
+            )),
+            makeLine(3, "prompt\$ echo world", listOf(
+                SemanticSegment(0, 8, SemanticType.PROMPT, promptId = 2),
+                SemanticSegment(8, 18, SemanticType.COMMAND_INPUT, promptId = 2)
+            )),
+            makeLine(4, "world"),
+            makeLine(5, "", listOf(
+                SemanticSegment(0, 0, SemanticType.COMMAND_FINISHED, metadata = "0", promptId = 2)
+            ))
+        )
+
+        // Should return only the last command's output
+        val output = getLastCommandOutput(lines)
+        assertNotNull(output)
+        assertEquals("world", output)
+    }
+
+    @Test
+    fun testMultiLineOutput() {
+        val lines = listOf(
+            makeLine(0, "prompt\$ find .", listOf(
+                SemanticSegment(0, 8, SemanticType.PROMPT, promptId = 1),
+                SemanticSegment(8, 14, SemanticType.COMMAND_INPUT, promptId = 1)
+            )),
+            makeLine(1, "./src"),
+            makeLine(2, "./src/main"),
+            makeLine(3, "./src/test"),
+            makeLine(4, "", listOf(
+                SemanticSegment(0, 0, SemanticType.COMMAND_FINISHED, metadata = "0", promptId = 1)
+            ))
+        )
+
+        val output = getLastCommandOutput(lines)
+        assertNotNull(output)
+        assertEquals("./src\n./src/main\n./src/test", output)
+    }
+
+    @Test
+    fun testOutputWithTrailingWhitespace() {
+        val lines = listOf(
+            makeLine(0, "prompt\$ cmd", listOf(
+                SemanticSegment(0, 8, SemanticType.PROMPT, promptId = 1),
+                SemanticSegment(8, 11, SemanticType.COMMAND_INPUT, promptId = 1)
+            )),
+            makeLine(1, "output   "),
+            makeLine(2, "   "),
+            makeLine(3, "", listOf(
+                SemanticSegment(0, 0, SemanticType.COMMAND_FINISHED, metadata = "0", promptId = 1)
+            ))
+        )
+
+        val output = getLastCommandOutput(lines)
+        assertNotNull(output)
+        // Each line is trimEnd'd, then the whole string is trimEnd'd
+        assertEquals("output", output)
+    }
+
+    @Test
+    fun testCommandInputAndFinishedAdjacent() {
+        // COMMAND_INPUT on line 0, COMMAND_FINISHED on line 1 with no output between
+        val lines = listOf(
+            makeLine(0, "prompt\$ true", listOf(
+                SemanticSegment(0, 8, SemanticType.PROMPT, promptId = 1),
+                SemanticSegment(8, 12, SemanticType.COMMAND_INPUT, promptId = 1)
+            )),
+            makeLine(1, "", listOf(
+                SemanticSegment(0, 0, SemanticType.COMMAND_FINISHED, metadata = "0", promptId = 1)
+            ))
+        )
+
+        // No lines between input and finished
+        assertNull(getLastCommandOutput(lines))
+    }
+
+    @Test
+    fun testOutputFromScrollback() {
+        // Simulates output that has scrolled into scrollback
+        val lines = listOf(
+            // Scrollback lines
+            makeLine(-1, "prompt\$ ls -la", listOf(
+                SemanticSegment(0, 8, SemanticType.PROMPT, promptId = 1),
+                SemanticSegment(8, 14, SemanticType.COMMAND_INPUT, promptId = 1)
+            )),
+            makeLine(-1, "total 42"),
+            makeLine(-1, "drwxr-xr-x  2 user group 4096 Jan 1 file1"),
+            makeLine(-1, "drwxr-xr-x  2 user group 4096 Jan 1 file2"),
+            // Visible screen
+            makeLine(0, "", listOf(
+                SemanticSegment(0, 0, SemanticType.COMMAND_FINISHED, metadata = "0", promptId = 1)
+            )),
+            makeLine(1, "prompt\$ ", listOf(
+                SemanticSegment(0, 8, SemanticType.PROMPT, promptId = 2)
+            ))
+        )
+
+        val output = getLastCommandOutput(lines)
+        assertNotNull(output)
+        assertEquals(
+            "total 42\ndrwxr-xr-x  2 user group 4096 Jan 1 file1\ndrwxr-xr-x  2 user group 4096 Jan 1 file2",
+            output
+        )
+    }
+
+    private fun makeLine(
+        row: Int,
+        text: String,
+        segments: List<SemanticSegment> = emptyList()
+    ): TerminalLine {
+        val cells = text.map { char ->
+            TerminalLine.Cell(
+                char = char,
+                fgColor = Color.White,
+                bgColor = Color.Black
+            )
+        }
+        return TerminalLine(row = row, cells = cells, semanticSegments = segments)
+    }
+}


### PR DESCRIPTION
Fix #28.
Add the ability to retrieve the output of the last completed command using OSC 133 (FinalTerm) shell integration semantic markers. This is exposed through:                                                                                                                                           
                                                                                                                                                     
  - A TalkBack custom accessibility action ("Read Last Output") that announces the output via announceForAccessibility                               
  - A public API (TerminalEmulator.getLastCommandOutput()) that ConnectBot uses to expose this in a menu item
                                              
## How it works                                                                                                                                       
                                                                                                                                                     
  The implementation scans backward through terminal lines (scrollback + visible) to find:                                                           
  1. The most recent COMMAND_FINISHED marker (OSC 133;D)                                                                                             
  2. The matching COMMAND_INPUT marker (OSC 133;B) with the same promptId                                                                            
  3. All lines between them, which are the command output                                                                                                                                                                               
                                                                                                                                                     
## Changes                                                                                                                                            
                                                                                                                                                     
  AccessibilityOverlay.kt                                                                                                                            
                                                                                                                                                     
  - Add getLastCommandOutput(lines) internal function that extracts the last command's output text from semantic segments                            
  - Add "Read Last Output" custom accessibility action that calls getLastCommandOutput() and announces the result via TalkBack                       
                                                                                                                                                     
  TerminalEmulator.kt                                                                                                                                
                                                                                                                                                     
  - Add getLastCommandOutput(): String? to the public TerminalEmulator sealed interface                                                              
  - Implement in TerminalEmulatorImpl by reading the current snapshot's scrollback + visible lines and delegating to getLastCommandOutput(lines)     
                                                                                                                                                     
  OscParser.kt                                                                                                                                       
                                                                                                                                                     
  - Move COMMAND_INPUT segment creation from C time (OSC 133;C) to B time (OSC 133;B). In real shell integration, the user presses Enter  before C is sent, which scrolls the terminal. Since libvterm uses screen-relative cursor positions, the cursor row stays the same after scroll   while the column resets to 0, causing the old column comparison to always fail. Creating the segment at B time ensures it is placed on the correct screen row and gets properly shifted by pushScrollbackLine along with the text content.                                                            
                                                                                                                                                     
  ReadLastOutputTest.kt (new)                                                                                                                        
                                                                                                                                                     
  - 8 unit tests covering: basic output, no finished marker, no input marker, empty output, multiple commands, multi-line output, trailing           
  whitespace, and scrollback scenarios                                                                                                               
                                                                                                                                                     
  OscParserTest.kt                                                                                                                                   
                                                                                                                                                     
  - Update testOsc133PromptFlow for new behavior (B now emits both PROMPT and COMMAND_INPUT)                                                         
  - Add testOsc133PromptFlowCrossRow covering the realistic scenario where scroll keeps the cursor at the same screen-relative row                   
                                                                                                                                                     
## Unit Tests                                                                                                                     
                                                                                                                                                     
  - ReadLastOutputTest — 8 tests covering getLastCommandOutput() logic                                                                               
  - OscParserTest.testOsc133PromptFlow — same-row OSC 133 flow                                                                                       
  - OscParserTest.testOsc133PromptFlowCrossRow — cross-scroll OSC 133 flow (the real-world case)                                                     
  - Manual test on device with bash OSC 133 shell integration: run commands, verify TalkBack action and public API both return correct output 