### PR TITLE
fix(physical-keyboard): remove resetImeBuffer

### DIFF
--- a/lib/src/main/java/org/connectbot/terminal/Terminal.kt
+++ b/lib/src/main/java/org/connectbot/terminal/Terminal.kt
@@ -64,10 +64,8 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.input.key.Key
-import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onPreviewKeyEvent
-import androidx.compose.ui.input.key.type
 import androidx.compose.ui.input.pointer.PointerEvent
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
@@ -656,17 +654,11 @@ fun TerminalWithAccessibility(
                                     else -> {
                                         // Any other key exits Review Mode and goes to shell
                                         isReviewMode = false
-                                        if (event.type == KeyEventType.KeyDown) {
-                                            imeInputView?.resetImeBuffer()
-                                        }
                                         keyboardHandler.onKeyEvent(event)
                                     }
                                 }
                             } else {
                                 // Input Mode: send all keys to shell
-                                if (event.type == KeyEventType.KeyDown) {
-                                    imeInputView?.resetImeBuffer()
-                                }
                                 keyboardHandler.onKeyEvent(event)
                             }
                         }


### PR DESCRIPTION
This might be interfering with physical keyboard input if the IME responds to IME buffer changes by calling .commitText at the wrong time. Just remove it.