### PR TITLE
Fix dupchar

### DIFF
--- a/lib/src/androidTest/java/org/connectbot/terminal/ImeInputViewTest.kt
+++ b/lib/src/androidTest/java/org/connectbot/terminal/ImeInputViewTest.kt
@@ -212,7 +212,12 @@ class ImeInputViewTest {
     // === IME duplicate character tests (connectbot/connectbot#1955) ===
 
     private fun createIntegrationInputConnection(): Pair<TerminalEmulator, InputConnection> {
-        val emulator = TerminalEmulatorFactory.create(initialRows = 24, initialCols = 80)
+        lateinit var emulator: TerminalEmulator
+        emulator = TerminalEmulatorFactory.create(
+            initialRows = 24,
+            initialCols = 80,
+            onKeyboardInput = { data -> emulator.writeInput(data) }
+        )
         val handler = KeyboardHandler(emulator)
         var ic: InputConnection? = null
         InstrumentationRegistry.getInstrumentation().runOnMainSync {

--- a/lib/src/androidTest/java/org/connectbot/terminal/ImeInputViewTest.kt
+++ b/lib/src/androidTest/java/org/connectbot/terminal/ImeInputViewTest.kt
@@ -19,6 +19,7 @@ package org.connectbot.terminal
 import android.view.KeyEvent
 import android.view.inputmethod.BaseInputConnection
 import android.view.inputmethod.EditorInfo
+import android.view.inputmethod.InputConnection
 import android.view.inputmethod.InputMethodManager
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
@@ -206,5 +207,61 @@ class ImeInputViewTest {
 
         assertEquals("", ic.getEditable()?.toString())
         verify { imm.updateSelection(view, 0, 0, -1, -1) }
+    }
+
+    // === IME duplicate character tests (connectbot/connectbot#1955) ===
+
+    private fun createIntegrationInputConnection(): Pair<TerminalEmulator, InputConnection> {
+        val emulator = TerminalEmulatorFactory.create(initialRows = 24, initialCols = 80)
+        val handler = KeyboardHandler(emulator)
+        var ic: InputConnection? = null
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            val view = ImeInputView(context, handler)
+            view.setOnKeyListener { _, _, event ->
+                handler.onKeyEvent(
+                    androidx.compose.ui.input.key.KeyEvent(event)
+                )
+            }
+            ic = view.onCreateInputConnection(EditorInfo())
+        }
+        return emulator to ic!!
+    }
+
+    private fun getScreenText(emulator: TerminalEmulator, row: Int): String {
+        val impl = emulator as TerminalEmulatorImpl
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+        impl.processPendingUpdates()
+        return impl.snapshot.value.lines[row].text.trimEnd('\u0000')
+    }
+
+    @Test
+    fun testCommitAfterComposingDoesNotDuplicate() {
+        val (emulator, ic) = createIntegrationInputConnection()
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            ic.setComposingText("a", 1)
+            ic.commitText("a", 1)
+        }
+        assertEquals("a", getScreenText(emulator, 0))
+    }
+
+    @Test
+    fun testMultiCharComposingCommitDoesNotDuplicate() {
+        val (emulator, ic) = createIntegrationInputConnection()
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            ic.setComposingText("h", 1)
+            ic.setComposingText("he", 1)
+            ic.setComposingText("hel", 1)
+            ic.commitText("hel", 1)
+        }
+        assertEquals("hel", getScreenText(emulator, 0))
+    }
+
+    @Test
+    fun testDirectCommitWithoutComposing() {
+        val (emulator, ic) = createIntegrationInputConnection()
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            ic.commitText("x", 1)
+        }
+        assertEquals("x", getScreenText(emulator, 0))
     }
 }

--- a/lib/src/androidTest/java/org/connectbot/terminal/ImeInputViewTest.kt
+++ b/lib/src/androidTest/java/org/connectbot/terminal/ImeInputViewTest.kt
@@ -211,17 +211,18 @@ class ImeInputViewTest {
 
     // === IME duplicate character tests (connectbot/connectbot#1955) ===
 
-    private fun createIntegrationInputConnection(): Pair<TerminalEmulator, InputConnection> {
-        lateinit var emulator: TerminalEmulator
-        emulator = TerminalEmulatorFactory.create(
+    private fun createKeyboardOutputCapture(): Pair<InputConnection, MutableList<ByteArray>> {
+        val outputs = mutableListOf<ByteArray>()
+        val emulator = TerminalEmulatorFactory.create(
             initialRows = 24,
             initialCols = 80,
-            onKeyboardInput = { data -> emulator.writeInput(data) }
+            onKeyboardInput = { data -> outputs.add(data.copyOf()) }
         )
         val handler = KeyboardHandler(emulator)
         var ic: InputConnection? = null
         InstrumentationRegistry.getInstrumentation().runOnMainSync {
             val view = ImeInputView(context, handler)
+            view.isComposeModeActive = true
             view.setOnKeyListener { _, _, event ->
                 handler.onKeyEvent(
                     androidx.compose.ui.input.key.KeyEvent(event)
@@ -229,44 +230,64 @@ class ImeInputViewTest {
             }
             ic = view.onCreateInputConnection(EditorInfo())
         }
-        return emulator to ic!!
+        return ic!! to outputs
     }
 
-    private fun getScreenText(emulator: TerminalEmulator, row: Int): String {
-        val impl = emulator as TerminalEmulatorImpl
+    /**
+     * Compute the effective text from captured keyboard output by applying
+     * BS (0x08) and DEL (0x7F) as character erasure operations.
+     */
+    private fun effectiveText(outputs: List<ByteArray>): String {
+        val buffer = StringBuilder()
+        for (data in outputs) {
+            for (byte in data) {
+                val code = byte.toInt() and 0xFF
+                when {
+                    code == 0x08 || code == 0x7F -> {
+                        if (buffer.isNotEmpty()) buffer.deleteCharAt(buffer.length - 1)
+                    }
+                    code >= 0x20 -> buffer.append(byte.toInt().toChar())
+                }
+            }
+        }
+        return buffer.toString()
+    }
+
+    private fun drainMainLooper() {
         InstrumentationRegistry.getInstrumentation().waitForIdleSync()
-        impl.processPendingUpdates()
-        return impl.snapshot.value.lines[row].text.trimEnd('\u0000')
     }
 
     @Test
     fun testCommitAfterComposingDoesNotDuplicate() {
-        val (emulator, ic) = createIntegrationInputConnection()
+        val (ic, outputs) = createKeyboardOutputCapture()
         InstrumentationRegistry.getInstrumentation().runOnMainSync {
             ic.setComposingText("a", 1)
             ic.commitText("a", 1)
         }
-        assertEquals("a", getScreenText(emulator, 0))
+        drainMainLooper()
+        assertEquals("a", effectiveText(outputs))
     }
 
     @Test
     fun testMultiCharComposingCommitDoesNotDuplicate() {
-        val (emulator, ic) = createIntegrationInputConnection()
+        val (ic, outputs) = createKeyboardOutputCapture()
         InstrumentationRegistry.getInstrumentation().runOnMainSync {
             ic.setComposingText("h", 1)
             ic.setComposingText("he", 1)
             ic.setComposingText("hel", 1)
             ic.commitText("hel", 1)
         }
-        assertEquals("hel", getScreenText(emulator, 0))
+        drainMainLooper()
+        assertEquals("hel", effectiveText(outputs))
     }
 
     @Test
     fun testDirectCommitWithoutComposing() {
-        val (emulator, ic) = createIntegrationInputConnection()
+        val (ic, outputs) = createKeyboardOutputCapture()
         InstrumentationRegistry.getInstrumentation().runOnMainSync {
             ic.commitText("x", 1)
         }
-        assertEquals("x", getScreenText(emulator, 0))
+        drainMainLooper()
+        assertEquals("x", effectiveText(outputs))
     }
 }

--- a/lib/src/main/java/org/connectbot/terminal/ImeInputView.kt
+++ b/lib/src/main/java/org/connectbot/terminal/ImeInputView.kt
@@ -223,16 +223,18 @@ internal class ImeInputView(
 
         override fun commitText(text: CharSequence?, newCursorPosition: Int): Boolean {
             val committedText = text?.toString() ?: ""
+            // Save composingText before super.commitText() which internally calls
+            // finishComposingText(), clearing composingText before we can use it.
+            val previousComposingText = composingText
             super.commitText(text, newCursorPosition)
 
             if (committedText.isNotEmpty()) {
-                if (composingText.isNotEmpty()) {
-                    sendBackspaces(composingText.length)
+                if (previousComposingText.isNotEmpty()) {
+                    sendBackspaces(previousComposingText.length)
                 }
                 sendTextInput(committedText)
             }
             composingText = ""
-            // Clear the internal Editable to prevent unbounded accumulation
             editable?.clear()
             return true
         }


### PR DESCRIPTION
Fix on-screen keyboards duplicating every character (connectbot/connectbot#1955)
  - super.commitText() internally calls finishComposingText(), which cleared composingText before the backspace guard in commitText() could execute —   causing composed text to be sent twice
  - Save composingText before calling super.commitText() so the backspace guard correctly removes the previously composed text

  Test plan

  - testCommitAfterComposingDoesNotDuplicate
  - testMultiCharComposingCommitDoesNotDuplicate
  - testDirectCommitWithoutComposing