### PR TITLE
Fix URL detection across soft-wrapped terminal lines

### DIFF
--- a/lib/src/main/java/org/connectbot/terminal/Terminal.kt
+++ b/lib/src/main/java/org/connectbot/terminal/Terminal.kt
@@ -1023,8 +1023,11 @@ fun TerminalWithAccessibility(
                                         .coerceIn(0, screenState.snapshot.cols - 1)
                                     val tapRow = (down.position.y / baseCharHeight).toInt()
                                         .coerceIn(0, screenState.snapshot.rows - 1)
-                                    val line = screenState.getVisibleLine(tapRow)
-                                    val hyperlinkUrl = line.getHyperlinkUrlAt(tapCol)
+                                    // Check hyperlinks first — they take priority over
+                                    // mouse mode callbacks so URLs are always tappable.
+                                    // Uses screen-state method which joins soft-wrapped
+                                    // lines for cross-line URL detection.
+                                    val hyperlinkUrl = screenState.getHyperlinkUrlAt(tapRow, tapCol)
 
                                     if (hyperlinkUrl != null) {
                                         // User tapped on a hyperlink

--- a/lib/src/main/java/org/connectbot/terminal/TerminalScreenState.kt
+++ b/lib/src/main/java/org/connectbot/terminal/TerminalScreenState.kt
@@ -112,6 +112,55 @@ internal class TerminalScreenState(
     }
 
     /**
+     * Get the hyperlink URL at a visible row/col, handling URLs that span
+     * soft-wrapped lines. Joins consecutive soft-wrapped lines before URL
+     * detection so that long URLs wrapping across lines are matched fully.
+     */
+    fun getHyperlinkUrlAt(row: Int, col: Int): String? {
+        val line = getVisibleLine(row)
+
+        // OSC 8 segments always take priority (they don't span lines)
+        val osc8 = line.semanticSegments.firstOrNull {
+            it.semanticType == SemanticType.HYPERLINK && it.contains(col)
+        }?.metadata
+        if (osc8 != null) return osc8
+
+        // Build the joined text from consecutive soft-wrapped lines
+        // Walk backward to find the first line in this soft-wrap group
+        var startRow = row
+        while (startRow > 0) {
+            val prev = getVisibleLine(startRow - 1)
+            if (!prev.softWrapped) break
+            startRow--
+        }
+        // Walk forward to find the last line
+        var endRow = row
+        while (getVisibleLine(endRow).softWrapped && endRow < snapshot.rows - 1) {
+            endRow++
+        }
+
+        // If no wrapping, fall back to single-line detection
+        if (startRow == endRow) {
+            return line.autoDetectedUrls.firstOrNull { col >= it.first && col < it.second }?.third
+        }
+
+        // Join lines and compute the adjusted column offset
+        val joined = StringBuilder()
+        var colOffset = 0
+        for (r in startRow..endRow) {
+            val l = getVisibleLine(r)
+            if (r == row) colOffset = joined.length
+            joined.append(l.text)
+        }
+        val absoluteCol = colOffset + col
+
+        // Find URLs in the joined text
+        return TerminalLine.URL_REGEX.findAll(joined).firstOrNull { match ->
+            absoluteCol >= match.range.first && absoluteCol <= match.range.last
+        }?.value
+    }
+
+    /**
      * Scroll to the bottom (current screen).
      */
     fun scrollToBottom() {


### PR DESCRIPTION
## Summary
- URLs that wrap across soft-wrapped terminal lines are now detected as a single URL when tapped
- `TerminalScreenState.getHyperlinkUrlAt(row, col)` joins consecutive soft-wrapped lines before running URL regex
- Tapping any part of a wrapped URL opens the full URL

## Problem
As noted in the #151 review, URL auto-detection runs per-line, so a long URL that wraps across lines would only match the fragment on each line. For example:

```
https://example.com/very/long/path/that/wraps-to-the-
next-line/continuing-here
```

Would previously match `https://example.com/very/long/path/that/wraps-to-the-` (truncated) on the first line.

## Approach
The tap handler now calls `TerminalScreenState.getHyperlinkUrlAt(row, col)` which:
1. Checks OSC 8 segments first (unchanged)
2. Walks backward/forward to find the soft-wrap group boundaries
3. Joins the group's text and runs the URL regex on the joined string
4. Maps the tap column back to the correct position in the joined text

The per-line `autoDetectedUrls` and underline rendering remain unchanged (the `drawLine` function doesn't have screen-state context), so underlines may still break at line boundaries, but the tap target correctly resolves the full URL.

## Test plan
- [x] Long URL wrapping across 2+ lines: tap on either line opens the full URL
- [x] Short URL within a single line: unchanged behavior
- [x] OSC 8 hyperlinks: still take priority
- [x] Build passes