### PR TITLE
Detect and underline URLs spanning multiple terminal lines

### DIFF
--- a/lib/src/main/java/org/connectbot/terminal/Terminal.kt
+++ b/lib/src/main/java/org/connectbot/terminal/Terminal.kt
@@ -1023,8 +1023,9 @@ fun TerminalWithAccessibility(
                                         .coerceIn(0, screenState.snapshot.cols - 1)
                                     val tapRow = (down.position.y / baseCharHeight).toInt()
                                         .coerceIn(0, screenState.snapshot.rows - 1)
-                                    val line = screenState.getVisibleLine(tapRow)
-                                    val hyperlinkUrl = line.getHyperlinkUrlAt(tapCol)
+                                    // Use screen-state method which joins adjacent
+                                    // lines for cross-line URL detection.
+                                    val hyperlinkUrl = screenState.getHyperlinkUrlAt(tapRow, tapCol)
 
                                     if (hyperlinkUrl != null) {
                                         // User tapped on a hyperlink
@@ -1066,11 +1067,28 @@ fun TerminalWithAccessibility(
                 )
 
                 // Draw each line (zoom/pan applied via graphicsLayer)
+                // Precompute which rows are part of a multi-line URL group.
+                // A row is a URL continuation if it and the previous row end/start
+                // with URL-safe chars and the chain traces back to a detected URL.
+                val urlContinuationRows = mutableSetOf<Int>()
+                for (row in 1 until screenState.snapshot.rows) {
+                    val prev = screenState.getVisibleLine(row - 1).text.trimEnd()
+                    val cur = screenState.getVisibleLine(row).text.trimStart()
+                    if (prev.isNotEmpty() && cur.isNotEmpty() &&
+                        prev.last().isUrlSafe() && cur.first().isUrlSafe()) {
+                        if ((row - 1) in urlContinuationRows ||
+                            screenState.getVisibleLine(row - 1).autoDetectedUrls.isNotEmpty()) {
+                            urlContinuationRows.add(row)
+                        }
+                    }
+                }
+
                 for (row in 0 until screenState.snapshot.rows) {
                     val line = screenState.getVisibleLine(row)
                     drawLine(
                         line = line,
                         row = row,
+                        isUrlContinuation = row in urlContinuationRows,
                         charWidth = baseCharWidth,
                         charHeight = baseCharHeight,
                         charBaseline = baseCharBaseline,
@@ -1240,6 +1258,7 @@ fun TerminalWithAccessibility(
 private fun DrawScope.drawLine(
     line: TerminalLine,
     row: Int,
+    isUrlContinuation: Boolean = false,
     charWidth: Float,
     charHeight: Float,
     charBaseline: Float,
@@ -1257,8 +1276,10 @@ private fun DrawScope.drawLine(
         // Check if this cell is selected
         val isSelected = selectionManager.isCellSelected(row, col)
 
-        // Check if this cell is part of a hyperlink
-        val isHyperlink = line.getHyperlinkUrlAt(col) != null
+        // Check if this cell is part of a hyperlink.
+        // For URL continuation rows, underline all non-whitespace content.
+        val isHyperlink = line.getHyperlinkUrlAt(col) != null ||
+            (isUrlContinuation && cell.char != ' ')
 
         // Determine colors (handle reverse video and selection)
         val fgColor = if (cell.reverse) cell.bgColor else cell.fgColor

--- a/lib/src/main/java/org/connectbot/terminal/Terminal.kt
+++ b/lib/src/main/java/org/connectbot/terminal/Terminal.kt
@@ -1085,10 +1085,23 @@ fun TerminalWithAccessibility(
 
                 for (row in 0 until screenState.snapshot.rows) {
                     val line = screenState.getVisibleLine(row)
+                    // For URL continuation rows, compute where the URL-safe
+                    // prefix ends: skip leading spaces, then find the first
+                    // space after URL-safe content.
+                    val urlEndCol = if (row in urlContinuationRows) {
+                        val cells = line.cells
+                        var i = 0
+                        // Skip leading spaces (left margin padding)
+                        while (i < cells.size && cells[i].char == ' ') i++
+                        // Advance through URL-safe characters
+                        while (i < cells.size && cells[i].char.isUrlSafe()) i++
+                        i
+                    } else 0
                     drawLine(
                         line = line,
                         row = row,
                         isUrlContinuation = row in urlContinuationRows,
+                        urlContinuationEndCol = urlEndCol,
                         charWidth = baseCharWidth,
                         charHeight = baseCharHeight,
                         charBaseline = baseCharBaseline,
@@ -1259,6 +1272,7 @@ private fun DrawScope.drawLine(
     line: TerminalLine,
     row: Int,
     isUrlContinuation: Boolean = false,
+    urlContinuationEndCol: Int = 0,
     charWidth: Float,
     charHeight: Float,
     charBaseline: Float,
@@ -1277,9 +1291,11 @@ private fun DrawScope.drawLine(
         val isSelected = selectionManager.isCellSelected(row, col)
 
         // Check if this cell is part of a hyperlink.
-        // For URL continuation rows, underline all non-whitespace content.
+        // For URL continuation rows, only underline the leading URL-safe
+        // prefix (spaces are allowed at the left/right terminal margins
+        // where wrapping occurs, but a mid-line space ends the URL).
         val isHyperlink = line.getHyperlinkUrlAt(col) != null ||
-            (isUrlContinuation && cell.char != ' ')
+            (isUrlContinuation && col < urlContinuationEndCol)
 
         // Determine colors (handle reverse video and selection)
         val fgColor = if (cell.reverse) cell.bgColor else cell.fgColor

--- a/lib/src/main/java/org/connectbot/terminal/Terminal.kt
+++ b/lib/src/main/java/org/connectbot/terminal/Terminal.kt
@@ -1076,6 +1076,7 @@ fun TerminalWithAccessibility(
                     val cur = screenState.getVisibleLine(row).text.trimStart()
                     if (prev.isNotEmpty() && cur.isNotEmpty() &&
                         prev.last().isUrlSafe() && cur.first().isUrlSafe()) {
+                        // Check that the chain traces back to a line with an actual URL
                         if ((row - 1) in urlContinuationRows ||
                             screenState.getVisibleLine(row - 1).autoDetectedUrls.isNotEmpty()) {
                             urlContinuationRows.add(row)

--- a/lib/src/main/java/org/connectbot/terminal/TerminalScreenState.kt
+++ b/lib/src/main/java/org/connectbot/terminal/TerminalScreenState.kt
@@ -112,6 +112,71 @@ internal class TerminalScreenState(
     }
 
     /**
+     * Get the hyperlink URL at a visible row/col, handling URLs that span
+     * multiple lines. Joins a small window of lines around the tap point,
+     * strips whitespace between URL-safe chars (wrap artifacts from CLI tools),
+     * and runs one regex match.
+     */
+    fun getHyperlinkUrlAt(row: Int, col: Int): String? {
+        val line = getVisibleLine(row)
+
+        // OSC 8 segments always take priority
+        val osc8 = line.semanticSegments.firstOrNull {
+            it.semanticType == SemanticType.HYPERLINK && it.contains(col)
+        }?.metadata
+        if (osc8 != null) return osc8
+
+        // Try single-line detection first (fast path, cached per line)
+        val singleHit = line.autoDetectedUrls.firstOrNull { col >= it.first && col < it.second }
+        if (singleHit != null) {
+            // If the match doesn't touch a line edge, it's self-contained
+            val trimmedLen = line.text.trimEnd().length
+            if (singleHit.second < trimmedLen && singleHit.first > 0) return singleHit.third
+        }
+
+        // Join a window of ±6 lines, strip inter-URL whitespace, single regex pass
+        val window = 6
+        val startRow = (row - window).coerceAtLeast(0)
+        val endRow = (row + window).coerceAtMost(snapshot.rows - 1)
+
+        val raw = StringBuilder()
+        var tapOffset = 0
+        for (r in startRow..endRow) {
+            if (r == row) tapOffset = raw.length
+            raw.append(getVisibleLine(r).text)
+        }
+
+        // Collapse whitespace runs between URL-safe chars (one pass).
+        // Lines are padded to terminal width, so between joined lines
+        // there can be 30+ trailing spaces — strip the entire run.
+        val cleaned = StringBuilder(raw.length)
+        val rawToClean = IntArray(raw.length)
+        var i = 0
+        while (i < raw.length) {
+            rawToClean[i] = cleaned.length
+            val ch = raw[i]
+            if ((ch == ' ' || ch == '\t') && i > 0 && raw[i - 1].isUrlSafe()) {
+                val wsStart = i
+                while (i < raw.length && (raw[i] == ' ' || raw[i] == '\t')) {
+                    rawToClean[i] = cleaned.length
+                    i++
+                }
+                if (i < raw.length && raw[i].isUrlSafe()) continue
+                for (j in wsStart until i) cleaned.append(raw[j])
+                continue
+            }
+            cleaned.append(ch)
+            i++
+        }
+        val cleanedCol = if (tapOffset + col in rawToClean.indices)
+            rawToClean[tapOffset + col] else tapOffset + col
+
+        return TerminalLine.URL_REGEX.findAll(cleaned).firstOrNull { m ->
+            cleanedCol >= m.range.first && cleanedCol <= m.range.last
+        }?.value ?: singleHit?.third
+    }
+
+    /**
      * Scroll to the bottom (current screen).
      */
     fun scrollToBottom() {
@@ -177,3 +242,6 @@ internal fun rememberTerminalScreenState(
 
     return state
 }
+
+/** True if the character commonly appears in URLs (query params, percent encoding, path). */
+internal fun Char.isUrlSafe(): Boolean = isLetterOrDigit() || this in "/:@!$&'()*+,;=-._~%?#[]"


### PR DESCRIPTION
## Summary

CLI tools (e.g. `claude-code`) output long URLs that wrap across multiple terminal lines with hard line breaks and trailing space padding. The existing single-line URL detection on `TerminalLine` misses these — only the first line is underlined and tappable.

- Add `TerminalScreenState.getHyperlinkUrlAt(row, col)` which joins a ±6 line window, collapses whitespace runs between URL-safe characters (terminal padding artifacts), and runs one regex pass
- Falls back to the fast single-line path for URLs that don't touch line edges
- Precompute URL continuation rows per frame for underline rendering — rows where both the previous line's end and current line's start are URL-safe and the chain traces back to a detected URL
- Continuation rows underline all non-whitespace content so the user sees the full multi-line URL is tappable

## Example

A URL like:
```
https://claude.com/cai/oauth/authorize?code=true&
client_id=9d1c250a-e61b-44d9-88ed-5944d1962f5e&re
sponse_type=code&redirect_uri=https%3A%2F%2Fplatf
orm.claude.com%2Foauth%2Fcode%2Fcallback&scope=or
g%3Acreate_api_key
```

Now underlines across all lines and tapping anywhere opens the full URL.

## Test plan

- [ ] Output a long URL (>1 line) in the terminal
- [ ] Verify all continuation lines are underlined
- [ ] Tap on any line of the URL — verify full URL is opened
- [ ] Verify single-line URLs still work as before
- [ ] Verify URLs that don't touch line edges return immediately (fast path)