### PR TITLE
fix(KeyboardHandler): handle Unicode input more gracefully

### DIFF
--- a/lib/api.txt
+++ b/lib/api.txt
@@ -60,7 +60,8 @@ package org.connectbot.terminal {
   public sealed nonexhaustive interface TerminalEmulator {
     method public void applyColorScheme(int[] ansiColors, int defaultForeground, int defaultBackground);
     method public void clearScreen();
-    method public void dispatchCharacter(int modifiers, char character);
+    method @Deprecated public default void dispatchCharacter(int modifiers, char ch);
+    method public void dispatchCharacter(int modifiers, int codepoint);
     method public void dispatchKey(int modifiers, int key);
     method @InaccessibleFromKotlin public org.connectbot.terminal.TerminalDimensions getDimensions();
     method public String? getLastCommandOutput();

--- a/lib/src/androidTest/java/org/connectbot/terminal/ImeInputViewTest.kt
+++ b/lib/src/androidTest/java/org/connectbot/terminal/ImeInputViewTest.kt
@@ -30,6 +30,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.text.Normalizer
 
 @RunWith(AndroidJUnit4::class)
 class ImeInputViewTest {
@@ -312,6 +313,68 @@ class ImeInputViewTest {
         }
         drainMainLooper()
         assertEquals("x", effectiveText(outputs))
+    }
+
+    // === Unicode precomposition (NFC normalization) ===
+
+    /**
+     * Some IMEs send decomposed Unicode (NFD): a base character followed by a combining
+     * diacritic as separate code points. The terminal must send the precomposed NFC form
+     * so the remote host receives a single character (e.g. ä U+00E4) rather than two
+     * separate code points (a U+0061 + combining umlaut U+0308).
+     */
+    @Test
+    fun testDecomposedUmlautIsPrecomposed() {
+        val (ic, outputs) = createKeyboardOutputCapture()
+        // NFD: 'a' (U+0061) + combining diaeresis (U+0308) → should arrive as NFC ä (U+00E4)
+        val nfdUmlaut = "a\u0308"
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            ic.commitText(nfdUmlaut, 1)
+        }
+        drainMainLooper()
+        val received = outputs.flatMap { it.toList() }.toByteArray().toString(Charsets.UTF_8)
+        val expected = Normalizer.normalize(nfdUmlaut, Normalizer.Form.NFC)
+        assertEquals(expected, received)
+    }
+
+    @Test
+    fun testDecomposedCircumflexIsPrecomposed() {
+        val (ic, outputs) = createKeyboardOutputCapture()
+        // NFD: 'e' (U+0065) + combining circumflex (U+0302) → should arrive as NFC ê (U+00EA)
+        val nfdCircumflex = "e\u0302"
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            ic.commitText(nfdCircumflex, 1)
+        }
+        drainMainLooper()
+        val received = outputs.flatMap { it.toList() }.toByteArray().toString(Charsets.UTF_8)
+        val expected = Normalizer.normalize(nfdCircumflex, Normalizer.Form.NFC)
+        assertEquals(expected, received)
+    }
+
+    @Test
+    fun testAlreadyNfcTextIsUnchanged() {
+        val (ic, outputs) = createKeyboardOutputCapture()
+        // NFC ä (U+00E4) should pass through unchanged
+        val nfcUmlaut = "\u00E4"
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            ic.commitText(nfcUmlaut, 1)
+        }
+        drainMainLooper()
+        val received = outputs.flatMap { it.toList() }.toByteArray().toString(Charsets.UTF_8)
+        assertEquals(nfcUmlaut, received)
+    }
+
+    @Test
+    fun testSurrogatePairSentAsOneCodepoint() {
+        val (ic, outputs) = createKeyboardOutputCapture()
+        // U+1F600 GRINNING FACE — encoded as a surrogate pair in Java/Kotlin strings
+        val emoji = "\uD83D\uDE00"
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            ic.commitText(emoji, 1)
+        }
+        drainMainLooper()
+        val received = outputs.flatMap { it.toList() }.toByteArray().toString(Charsets.UTF_8)
+        assertEquals(emoji, received)
     }
 
     // === Soft-keyboard TYPE_NULL key event routing ===

--- a/lib/src/main/java/org/connectbot/terminal/KeyboardHandler.kt
+++ b/lib/src/main/java/org/connectbot/terminal/KeyboardHandler.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.input.key.isShiftPressed
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.input.key.KeyEvent as ComposeKeyEvent
+import java.text.Normalizer
 
 /**
  * Handles keyboard input conversion for terminal emulation.
@@ -71,8 +72,8 @@ internal class KeyboardHandler(
             when (key) {
                 Key.Enter -> {
                     val text = compose.commit()
-                    text?.forEach { char ->
-                        terminalEmulator.dispatchCharacter(0, char)
+                    text?.codePoints()?.forEach { codepoint ->
+                        terminalEmulator.dispatchCharacter(0, codepoint)
                     }
                     onInputProcessed?.invoke()
                 }
@@ -143,7 +144,7 @@ internal class KeyboardHandler(
         // Handle regular printable characters
         val char = getCharacterFromKey(key, shift || modifierManager?.isShiftActive() == true)
         if (char != null) {
-            terminalEmulator.dispatchCharacter(modifiers, char)
+            terminalEmulator.dispatchCharacter(modifiers, char.code)
             modifierManager?.clearTransients()
             onInputProcessed?.invoke()
             return true
@@ -165,7 +166,7 @@ internal class KeyboardHandler(
 
         val modifiers = buildModifierMask(ctrl, alt, false)
 
-        terminalEmulator.dispatchCharacter(modifiers, char)
+        terminalEmulator.dispatchCharacter(modifiers, char.code)
         modifierManager?.clearTransients()
         onInputProcessed?.invoke()
         return true
@@ -178,18 +179,20 @@ internal class KeyboardHandler(
     fun onTextInput(bytes: ByteArray) {
         if (bytes.isEmpty()) return
 
+        val raw = bytes.toString(Charsets.UTF_8)
+        val text = if (Normalizer.isNormalized(raw, Normalizer.Form.NFC)) raw
+                   else Normalizer.normalize(raw, Normalizer.Form.NFC)
+
         val compose = composeMode
         if (compose != null && compose.isActive) {
-            val text = bytes.toString(Charsets.UTF_8)
             compose.appendText(text)
             return
         }
 
         val modifiers = getModifierMask()
-        val text = bytes.toString(Charsets.UTF_8)
 
-        text.forEach { char ->
-            terminalEmulator.dispatchCharacter(modifiers, char)
+        text.codePoints().forEach { codepoint ->
+            terminalEmulator.dispatchCharacter(modifiers, codepoint)
         }
         modifierManager?.clearTransients()
         onInputProcessed?.invoke()

--- a/lib/src/main/java/org/connectbot/terminal/TerminalEmulator.kt
+++ b/lib/src/main/java/org/connectbot/terminal/TerminalEmulator.kt
@@ -56,7 +56,16 @@ sealed interface TerminalEmulator {
     /**
      * Dispatch a character to the terminal.
      */
-    fun dispatchCharacter(modifiers: Int, character: Char)
+    @Deprecated(
+        message = "Use dispatchCharacter(modifiers, codepoint) for full Unicode code point support",
+        replaceWith = ReplaceWith("dispatchCharacter(modifiers, ch.code)")
+    )
+    fun dispatchCharacter(modifiers: Int, ch: Char) = dispatchCharacter(modifiers, ch.code)
+
+    /**
+     * Dispatch a character to the terminal.
+     */
+    fun dispatchCharacter(modifiers: Int, codepoint: Int)
 
     /**
      * Clears the terminal emulator screen.
@@ -341,8 +350,8 @@ internal class TerminalEmulatorImpl(
     /**
      * Dispatch a character to the terminal.
      */
-    override fun dispatchCharacter(modifiers: Int, character: Char) {
-        terminalNative.dispatchCharacter(modifiers, character.code)
+    override fun dispatchCharacter(modifiers: Int, codepoint: Int) {
+        terminalNative.dispatchCharacter(modifiers, codepoint)
     }
 
     /**


### PR DESCRIPTION
Normalize Unicode input (e.g., "u" plus umlaut combiner changes to single char). Start using Unicode codepoint (as Int) instead of the Char to avoid surrogate pair problems as well.

Should fix https://github.com/connectbot/connectbot/issues/2027