### PR TITLE
Enable bold-as-bright terminal colors

### DIFF
--- a/lib/src/androidTest/java/org/connectbot/terminal/ShellIntegrationTest.kt
+++ b/lib/src/androidTest/java/org/connectbot/terminal/ShellIntegrationTest.kt
@@ -2,9 +2,11 @@ package org.connectbot.terminal
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import androidx.compose.ui.graphics.Color
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -32,6 +34,7 @@ class ShellIntegrationTest {
     }
 
     private fun osc8End(): String = "\u001B]8;;\u001B\\"
+
     @Test
     fun testOsc133PromptMarker() = runBlocking {
         val emulator = TerminalEmulatorFactory.create(
@@ -105,6 +108,24 @@ class ShellIntegrationTest {
 
         val segment = annotatedLine!!.getSegmentsOfType(SemanticType.ANNOTATION).first()
         assertEquals(annotationMsg, segment.metadata)
+    }
+
+    @Test
+    fun testBoldBlackUsesBrightPaletteForIndexedColor() = runBlocking {
+        val emulator = TerminalEmulatorFactory.create(
+            initialRows = 5,
+            initialCols = 20
+        )
+
+        // Kismet uses indexed black on black plus bold, expecting xterm-style
+        // "bold as bright" behavior so the foreground becomes bright black.
+        emulator.writeInput("\u001B[38;5;0m\u001B[48;5;0m\u001B[1mX".toByteArray())
+
+        val snapshot = getSnapshot(emulator as TerminalEmulatorImpl)
+        val cell = snapshot.lines[0].cells[0]
+
+        assertEquals(Color.Black, cell.bgColor)
+        assertNotEquals("Bold black should promote to bright black", cell.bgColor, cell.fgColor)
     }
 
     @Test

--- a/lib/src/main/cpp/Terminal.cpp
+++ b/lib/src/main/cpp/Terminal.cpp
@@ -190,6 +190,9 @@ Terminal::Terminal(JNIEnv* env, jobject callbacks, int rows, int cols)
 
     // Set up OSC fallback handlers for shell integration
     VTermState* state = vterm_obtain_state(mVt);
+    // Match xterm's default boldColors behavior so applications that rely on
+    // bold-low-intensity colors promoting to the bright palette remain legible.
+    vterm_state_set_bold_highbright(state, 1);
     VTermStateFallbacks fallbacks = {
         .control = nullptr,
         .csi = nullptr,


### PR DESCRIPTION
Fixes connectbot/connectbot#2042.
Enable libvterm's bold-as-bright compatibility mode during terminal initialization.

  This matches xterm's default `boldColors` behavior and fixes applications that render low-intensity indexed colors with `SGR 1`, expecting the bright palette variant.

  ## Problem

  Some ncurses applications rely on sequences like:

```text
ESC[38;5;0m ESC[48;5;0m ESC[1m
```

  to render visible "bright black" text on a black background.

  With the current behavior, libvterm keeps that foreground as literally indexed black,  so these cells become black-on-black, and parts of the UI disappear.

  This showed up in ConnectBot as broken rendering in Kismet and similar terminal apps.

  ## Change

  In Terminal.cpp, after obtaining the VTermState, call:

 ```
vterm_state_set_bold_highbright(state, 1);
```

  This enables xterm-style promotion of low 8 foreground colors to their bright variants when bold is active.

  ## Tests

  Added an Android test regression case that writes:

```
  ESC[38;5;0m ESC[48;5;0m ESC[1m X
```

  and verifies the foreground no longer matches the black background.

  ## Why this default

  This is intended to be xterm-compatible behavior, and is a better fit for terminals
  advertising xterm / xterm-256color than leaving bold black as literal black.
 We can make it configurable if we really need to support non-xterm-like themes, but it would be nice to have. 