### PR TITLE
Pass key presses with meta modifiers onward

### DIFF
--- a/lib/src/androidTest/java/org/connectbot/terminal/ImeInputViewTest.kt
+++ b/lib/src/androidTest/java/org/connectbot/terminal/ImeInputViewTest.kt
@@ -554,4 +554,124 @@ class ImeInputViewTest {
         val received = outputs.flatMap { it.toList() }.toByteArray()
         assertTrue("ENTER via sendKeyEvent did not reach the terminal", received.contains(0x0D.toByte()))
     }
+
+    // === Ctrl/Alt modifier key routing from soft keyboards (issue-2050) ===
+    // Keyboards like "Unexpected keyboard" and SwiftKey send Ctrl/Alt combos via
+    // sendKeyEvent with metaState set. Unlike plain printable keys (which are dropped
+    // here to avoid doubling with Gboard's concurrent raw view event), modifier-carrying
+    // events must be forwarded since no competing raw view event is fired for them.
+
+    /**
+     * Ctrl+A via sendKeyEvent (metaState=META_CTRL_ON) must reach the terminal as 0x01.
+     * This is the path used by keyboards like "Unexpected keyboard" and SwiftKey.
+     */
+    @Test
+    fun testTypeNullSendKeyEventCtrlAProducesControlChar() {
+        val (ic, _, outputs) = createNonComposeModeCapture()
+
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            ic.sendKeyEvent(
+                KeyEvent(0, 0, KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_A, 0, KeyEvent.META_CTRL_ON)
+            )
+        }
+        drainMainLooper()
+
+        val received = outputs.flatMap { it.toList() }.toByteArray()
+        assertTrue("Ctrl+A via sendKeyEvent did not produce 0x01", received.contains(0x01.toByte()))
+    }
+
+    /**
+     * Ctrl+C via sendKeyEvent must reach the terminal as 0x03.
+     */
+    @Test
+    fun testTypeNullSendKeyEventCtrlCProducesControlChar() {
+        val (ic, _, outputs) = createNonComposeModeCapture()
+
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            ic.sendKeyEvent(
+                KeyEvent(0, 0, KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_C, 0, KeyEvent.META_CTRL_ON)
+            )
+        }
+        drainMainLooper()
+
+        val received = outputs.flatMap { it.toList() }.toByteArray()
+        assertTrue("Ctrl+C via sendKeyEvent did not produce 0x03", received.contains(0x03.toByte()))
+    }
+
+    /**
+     * Alt+A via sendKeyEvent (metaState=META_ALT_ON) must reach the terminal as ESC + 'a'.
+     */
+    @Test
+    fun testTypeNullSendKeyEventAltAProducesEscapePrefix() {
+        val (ic, _, outputs) = createNonComposeModeCapture()
+
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            ic.sendKeyEvent(
+                KeyEvent(0, 0, KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_A, 0, KeyEvent.META_ALT_ON)
+            )
+        }
+        drainMainLooper()
+
+        val received = outputs.flatMap { it.toList() }.toByteArray()
+        assertTrue("Alt+A via sendKeyEvent did not produce ESC prefix (0x1B)", received.contains(0x1B.toByte()))
+        assertTrue("Alt+A via sendKeyEvent did not produce 'a'", received.contains('a'.code.toByte()))
+    }
+
+    /**
+     * A plain printable key via sendKeyEvent (no modifier) must still be dropped to prevent
+     * doubling with Gboard's concurrent raw view event. This is a regression guard.
+     */
+    @Test
+    fun testTypeNullSendKeyEventPlainPrintableIsStillIgnored() {
+        val (ic, _, outputs) = createNonComposeModeCapture()
+
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            ic.sendKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_B))
+        }
+        drainMainLooper()
+
+        assertEquals("Plain printable key via sendKeyEvent should be dropped", "", effectiveText(outputs))
+    }
+
+    /**
+     * Space via sendKeyEvent (no modifier) must be dropped even though isPrintingKey() returns
+     * false for KEYCODE_SPACE (KeyCharacterMap classifies ' ' as SPACE_SEPARATOR, not printable).
+     * Gboard fires a concurrent raw View.dispatchKeyEvent for space; forwarding sendKeyEvent
+     * as well would cause a duplicate space.
+     */
+    @Test
+    fun testTypeNullSendKeyEventPlainSpaceIsIgnored() {
+        val (ic, _, outputs) = createNonComposeModeCapture()
+
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            ic.sendKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_SPACE))
+        }
+        drainMainLooper()
+
+        assertEquals("Plain space via sendKeyEvent should be dropped", "", effectiveText(outputs))
+    }
+
+    /**
+     * Ctrl modifier delivered via sendKeyEvent must not double when the same key is also
+     * delivered via raw View.dispatchKeyEvent without a modifier. The two events are
+     * independent: one carries the Ctrl combo, the other is a plain key press.
+     */
+    @Test
+    fun testTypeNullCtrlSendKeyEventAndPlainRawViewAreIndependent() {
+        val (ic, view, outputs) = createNonComposeModeCapture()
+
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            // Ctrl+A via sendKeyEvent → 0x01
+            ic.sendKeyEvent(
+                KeyEvent(0, 0, KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_A, 0, KeyEvent.META_CTRL_ON)
+            )
+            // Plain 'a' via raw view dispatch → 'a'
+            view.dispatchKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_A))
+        }
+        drainMainLooper()
+
+        val received = outputs.flatMap { it.toList() }.toByteArray()
+        assertTrue("Ctrl+A control char (0x01) missing", received.contains(0x01.toByte()))
+        assertTrue("Plain 'a' missing", received.contains('a'.code.toByte()))
+    }
 }

--- a/lib/src/androidTest/java/org/connectbot/terminal/ShellIntegrationTest.kt
+++ b/lib/src/androidTest/java/org/connectbot/terminal/ShellIntegrationTest.kt
@@ -1,13 +1,12 @@
 package org.connectbot.terminal
 
+import androidx.compose.ui.graphics.Color
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
-import androidx.compose.ui.graphics.Color
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNotEquals
-import org.junit.Assert.assertNull
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -192,7 +191,7 @@ class ShellIntegrationTest {
         impl.writeInput("\r\nEnd of test\r\n".toByteArray())
         impl.processPendingUpdates()
 
-        val snapshot = getSnapshot(emulator as TerminalEmulatorImpl)
+        val snapshot = getSnapshot(emulator)
 
         // Row 0: No hyperlinks (just header text)
         assertTrue(
@@ -278,7 +277,7 @@ class ShellIntegrationTest {
         impl.writeInput("${osc8Start("https://link3.com")}Link3${osc8End()}\r\n".toByteArray())
         impl.processPendingUpdates()
 
-        val snapshot = getSnapshot(emulator as TerminalEmulatorImpl)
+        val snapshot = getSnapshot(emulator)
 
         // After scrolling (7 lines, 5 rows = 3 scrolls), visible lines should be:
         // Row 0: "Plain text" (was line 3) - no hyperlink

--- a/lib/src/main/java/org/connectbot/terminal/ImeInputView.kt
+++ b/lib/src/main/java/org/connectbot/terminal/ImeInputView.kt
@@ -236,8 +236,17 @@ internal class ImeInputView(
                 //
                 // Non-printable keys (DEL, ENTER, arrows, etc.) do NOT get a competing raw
                 // view event from the soft keyboard, so we must forward them here.
-                if (event.action == KeyEvent.ACTION_DOWN && !event.isPrintingKey && event.keyCode != KeyEvent.KEYCODE_SPACE) {
-                    keyboardHandler.onKeyEvent(ComposeKeyEvent(event))
+                //
+                // Exception: keys carrying Ctrl or Alt modifiers in metaState must always
+                // be forwarded here — keyboards like "Unexpected keyboard" and SwiftKey send
+                // Ctrl/Alt combos only via sendKeyEvent and do not fire a competing raw view
+                // event for them.
+                if (event.action == KeyEvent.ACTION_DOWN) {
+                    val hasCtrlOrAlt = (event.metaState and
+                        (KeyEvent.META_CTRL_MASK or KeyEvent.META_ALT_MASK)) != 0
+                    if ((!event.isPrintingKey && event.keyCode != KeyEvent.KEYCODE_SPACE) || hasCtrlOrAlt) {
+                        keyboardHandler.onKeyEvent(ComposeKeyEvent(event))
+                    }
                 }
                 return true
             }


### PR DESCRIPTION
Some IMEs input keys with meta modifiers already set. Those will not have a corresponding commitText() call. We need to forward them to the keyboard handler to have them register as keypresses.

Fixes https://github.com/connectbot/connectbot/issues/2050