### PR TITLE
Another try at IME universal input handling

### DIFF
--- a/lib/src/androidTest/java/org/connectbot/terminal/ImeInputViewTest.kt
+++ b/lib/src/androidTest/java/org/connectbot/terminal/ImeInputViewTest.kt
@@ -392,7 +392,6 @@ class ImeInputViewTest {
 
         InstrumentationRegistry.getInstrumentation().runOnMainSync {
             view = ImeInputView(context, handler).also { v ->
-                // isComposeModeActive = false → TYPE_NULL path
                 v.setOnKeyListener { _, _, event ->
                     if (event.action == KeyEvent.ACTION_DOWN) v.resetImeBuffer()
                     handler.onKeyEvent(androidx.compose.ui.input.key.KeyEvent(event))
@@ -404,11 +403,10 @@ class ImeInputViewTest {
     }
 
     /**
-     * With TYPE_NULL, InputConnection.sendKeyEvent is ignored to prevent doubling with
-     * the raw view event that Gboard also fires.
+     * With TYPE_NULL, InputConnection.sendKeyEvent delivers the key directly to the terminal.
      */
     @Test
-    fun testTypeNullSendKeyEventIsIgnored() {
+    fun testTypeNullSendKeyEventDeliversCharacter() {
         val (ic, _, outputs) = createNonComposeModeCapture()
 
         InstrumentationRegistry.getInstrumentation().runOnMainSync {
@@ -416,12 +414,12 @@ class ImeInputViewTest {
         }
         drainMainLooper()
 
-        assertEquals("", effectiveText(outputs))
+        assertEquals("a", effectiveText(outputs))
     }
 
     /**
-     * With TYPE_NULL, events delivered via View.dispatchKeyEvent (Gboard's raw path)
-     * must reach the terminal.
+     * With TYPE_NULL, a raw view event (e.g. physical keyboard) that arrives independently
+     * of sendKeyEvent still reaches the terminal via setOnKeyListener.
      */
     @Test
     fun testTypeNullRawViewEventDeliversCharacter() {
@@ -472,8 +470,8 @@ class ImeInputViewTest {
     }
 
     /**
-     * With TYPE_NULL, a raw view key event (Gboard's concurrent dispatch path) still reaches
-     * the terminal via setOnKeyListener, and does not double with the sendKeyEvent path.
+     * Gboard sends via commitText AND fires a concurrent raw view event. The commitText
+     * path delivers the character; the raw view event is independent. Two 'a's total.
      */
     @Test
     fun testTypeNullRawViewEventAndCommitTextDeliverIndependently() {
@@ -556,10 +554,9 @@ class ImeInputViewTest {
     }
 
     // === Ctrl/Alt modifier key routing from soft keyboards (issue-2050) ===
-    // Keyboards like "Unexpected keyboard" and SwiftKey send Ctrl/Alt combos via
-    // sendKeyEvent with metaState set. Unlike plain printable keys (which are dropped
-    // here to avoid doubling with Gboard's concurrent raw view event), modifier-carrying
-    // events must be forwarded since no competing raw view event is fired for them.
+    // Keyboards like "Unexpected keyboard", SwiftKey, and Hacker's Keyboard send Ctrl/Alt
+    // combos via sendKeyEvent (with or without metaState). All sendKeyEvent calls are
+    // forwarded directly to keyboardHandler.
 
     /**
      * Ctrl+A via sendKeyEvent (metaState=META_CTRL_ON) must reach the terminal as 0x01.
@@ -618,11 +615,11 @@ class ImeInputViewTest {
     }
 
     /**
-     * A plain printable key via sendKeyEvent (no modifier) must still be dropped to prevent
-     * doubling with Gboard's concurrent raw view event. This is a regression guard.
+     * Plain printable key via sendKeyEvent (no modifier) delivers the character.
+     * Hacker's Keyboard uses this path for number keys.
      */
     @Test
-    fun testTypeNullSendKeyEventPlainPrintableIsStillIgnored() {
+    fun testTypeNullSendKeyEventPlainPrintableDeliversCharacter() {
         val (ic, _, outputs) = createNonComposeModeCapture()
 
         InstrumentationRegistry.getInstrumentation().runOnMainSync {
@@ -630,17 +627,16 @@ class ImeInputViewTest {
         }
         drainMainLooper()
 
-        assertEquals("Plain printable key via sendKeyEvent should be dropped", "", effectiveText(outputs))
+        assertEquals("b", effectiveText(outputs))
     }
 
     /**
-     * Space via sendKeyEvent (no modifier) must be dropped even though isPrintingKey() returns
-     * false for KEYCODE_SPACE (KeyCharacterMap classifies ' ' as SPACE_SEPARATOR, not printable).
-     * Gboard fires a concurrent raw View.dispatchKeyEvent for space; forwarding sendKeyEvent
-     * as well would cause a duplicate space.
+     * Space via sendKeyEvent delivers a space. KEYCODE_SPACE has isPrintingKey()=false
+     * (KeyCharacterMap classifies ' ' as SPACE_SEPARATOR), but it is still forwarded like
+     * all other sendKeyEvent keys.
      */
     @Test
-    fun testTypeNullSendKeyEventPlainSpaceIsIgnored() {
+    fun testTypeNullSendKeyEventSpaceDeliversSpace() {
         val (ic, _, outputs) = createNonComposeModeCapture()
 
         InstrumentationRegistry.getInstrumentation().runOnMainSync {
@@ -648,30 +644,7 @@ class ImeInputViewTest {
         }
         drainMainLooper()
 
-        assertEquals("Plain space via sendKeyEvent should be dropped", "", effectiveText(outputs))
+        assertEquals(" ", effectiveText(outputs))
     }
 
-    /**
-     * Ctrl modifier delivered via sendKeyEvent must not double when the same key is also
-     * delivered via raw View.dispatchKeyEvent without a modifier. The two events are
-     * independent: one carries the Ctrl combo, the other is a plain key press.
-     */
-    @Test
-    fun testTypeNullCtrlSendKeyEventAndPlainRawViewAreIndependent() {
-        val (ic, view, outputs) = createNonComposeModeCapture()
-
-        InstrumentationRegistry.getInstrumentation().runOnMainSync {
-            // Ctrl+A via sendKeyEvent → 0x01
-            ic.sendKeyEvent(
-                KeyEvent(0, 0, KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_A, 0, KeyEvent.META_CTRL_ON)
-            )
-            // Plain 'a' via raw view dispatch → 'a'
-            view.dispatchKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_A))
-        }
-        drainMainLooper()
-
-        val received = outputs.flatMap { it.toList() }.toByteArray()
-        assertTrue("Ctrl+A control char (0x01) missing", received.contains(0x01.toByte()))
-        assertTrue("Plain 'a' missing", received.contains('a'.code.toByte()))
-    }
 }

--- a/lib/src/main/java/org/connectbot/terminal/ImeInputView.kt
+++ b/lib/src/main/java/org/connectbot/terminal/ImeInputView.kt
@@ -230,23 +230,16 @@ internal class ImeInputView(
                 }
                 return result
             } else {
-                // TYPE_NULL mode: Gboard sends printable characters (a-z, etc.) via BOTH
-                // sendKeyEvent AND a raw View.dispatchKeyEvent. We ignore sendKeyEvent for
-                // those keys and rely on the raw view event to avoid doubling.
+                // TYPE_NULL mode: forward the key directly to keyboardHandler.
                 //
-                // Non-printable keys (DEL, ENTER, arrows, etc.) do NOT get a competing raw
-                // view event from the soft keyboard, so we must forward them here.
+                // Some IMEs (e.g. Gboard) also fire a concurrent raw View.dispatchKeyEvent
+                // for the same key, but since we call keyboardHandler directly here (not via
+                // dispatchKeyEvent), setOnKeyListener is never triggered — no duplication.
                 //
-                // Exception: keys carrying Ctrl or Alt modifiers in metaState must always
-                // be forwarded here — keyboards like "Unexpected keyboard" and SwiftKey send
-                // Ctrl/Alt combos only via sendKeyEvent and do not fire a competing raw view
-                // event for them.
+                // Other IMEs (e.g. Hacker's Keyboard) only use sendKeyEvent and fire no raw
+                // view event, so forwarding here is the only way their keys reach the terminal.
                 if (event.action == KeyEvent.ACTION_DOWN) {
-                    val hasCtrlOrAlt = (event.metaState and
-                        (KeyEvent.META_CTRL_MASK or KeyEvent.META_ALT_MASK)) != 0
-                    if ((!event.isPrintingKey && event.keyCode != KeyEvent.KEYCODE_SPACE) || hasCtrlOrAlt) {
-                        keyboardHandler.onKeyEvent(ComposeKeyEvent(event))
-                    }
+                    keyboardHandler.onKeyEvent(ComposeKeyEvent(event))
                 }
                 return true
             }
@@ -298,4 +291,5 @@ internal class ImeInputView(
             }
         }
     }
+
 }


### PR DESCRIPTION
Every keyboard seems to have a different way of handling how input is typed. This hopefully captures all of them in a way that reflects the intention of the user. The only problem is Hackers Keyboard has a workaround specifically for ConnectBot that does not work anymore.