### PR TITLE
Add bracketed paste support (DEC mode 2004)

### DIFF
--- a/lib/api.txt
+++ b/lib/api.txt
@@ -67,6 +67,7 @@ package org.connectbot.terminal {
     method @InaccessibleFromKotlin public boolean getBoldAsBright();
     method @InaccessibleFromKotlin public org.connectbot.terminal.TerminalDimensions getDimensions();
     method public String? getLastCommandOutput();
+    method public void paste(String text);
     method public void resize(int newRows, int newCols);
     method public int setAnsiPalette(int[] ansiColors);
     method public int setDefaultColors(int foreground, int background);

--- a/lib/src/androidTest/java/org/connectbot/terminal/BracketedPasteTest.kt
+++ b/lib/src/androidTest/java/org/connectbot/terminal/BracketedPasteTest.kt
@@ -17,6 +17,7 @@
 package org.connectbot.terminal
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -30,12 +31,20 @@ class BracketedPasteTest {
             onKeyboardInput = { bytes -> sink.append(bytes.toString(Charsets.UTF_8)) }
         )
 
+    // The keyboard-output callback is dispatched via a Handler on the main
+    // Looper (see TerminalEmulatorImpl.onKeyboardInput), so drain that queue
+    // before asserting.
+    private fun drainMainLooper() {
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+    }
+
     @Test
     fun pasteWithoutBracketedModeSendsTextRaw() {
         val out = StringBuilder()
         val term = newEmulator(out)
 
         term.paste("hello")
+        drainMainLooper()
 
         assertEquals("hello", out.toString())
     }
@@ -49,6 +58,7 @@ class BracketedPasteTest {
         term.writeInput("\u001B[?2004h".toByteArray(Charsets.UTF_8))
 
         term.paste("hello\nworld")
+        drainMainLooper()
 
         assertEquals("\u001B[200~hello\nworld\u001B[201~", out.toString())
     }
@@ -60,11 +70,13 @@ class BracketedPasteTest {
 
         term.writeInput("\u001B[?2004h".toByteArray(Charsets.UTF_8))
         term.paste("first")
+        drainMainLooper()
         val afterEnabled = out.toString()
 
         out.clear()
         term.writeInput("\u001B[?2004l".toByteArray(Charsets.UTF_8))
         term.paste("second")
+        drainMainLooper()
 
         assertEquals("\u001B[200~first\u001B[201~", afterEnabled)
         assertEquals("second", out.toString())
@@ -77,6 +89,7 @@ class BracketedPasteTest {
 
         term.writeInput("\u001B[?2004h".toByteArray(Charsets.UTF_8))
         term.paste("café 🚀")
+        drainMainLooper()
 
         assertEquals("\u001B[200~café 🚀\u001B[201~", out.toString())
     }

--- a/lib/src/androidTest/java/org/connectbot/terminal/BracketedPasteTest.kt
+++ b/lib/src/androidTest/java/org/connectbot/terminal/BracketedPasteTest.kt
@@ -1,0 +1,83 @@
+/*
+ * ConnectBot Terminal
+ * Copyright 2025 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.connectbot.terminal
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class BracketedPasteTest {
+    private fun newEmulator(sink: StringBuilder): TerminalEmulator =
+        TerminalEmulatorFactory.create(
+            initialRows = 24,
+            initialCols = 80,
+            onKeyboardInput = { bytes -> sink.append(bytes.toString(Charsets.UTF_8)) }
+        )
+
+    @Test
+    fun pasteWithoutBracketedModeSendsTextRaw() {
+        val out = StringBuilder()
+        val term = newEmulator(out)
+
+        term.paste("hello")
+
+        assertEquals("hello", out.toString())
+    }
+
+    @Test
+    fun pasteWrapsWithMarkersWhenBracketedModeEnabled() {
+        val out = StringBuilder()
+        val term = newEmulator(out)
+
+        // Remote enables DEC mode 2004 (bracketed paste)
+        term.writeInput("\u001B[?2004h".toByteArray(Charsets.UTF_8))
+
+        term.paste("hello\nworld")
+
+        assertEquals("\u001B[200~hello\nworld\u001B[201~", out.toString())
+    }
+
+    @Test
+    fun pasteRevertsToRawAfterBracketedModeDisabled() {
+        val out = StringBuilder()
+        val term = newEmulator(out)
+
+        term.writeInput("\u001B[?2004h".toByteArray(Charsets.UTF_8))
+        term.paste("first")
+        val afterEnabled = out.toString()
+
+        out.clear()
+        term.writeInput("\u001B[?2004l".toByteArray(Charsets.UTF_8))
+        term.paste("second")
+
+        assertEquals("\u001B[200~first\u001B[201~", afterEnabled)
+        assertEquals("second", out.toString())
+    }
+
+    @Test
+    fun pasteEncodesNonAsciiCodePointsAsUtf8() {
+        val out = StringBuilder()
+        val term = newEmulator(out)
+
+        term.writeInput("\u001B[?2004h".toByteArray(Charsets.UTF_8))
+        term.paste("café 🚀")
+
+        assertEquals("\u001B[200~café 🚀\u001B[201~", out.toString())
+    }
+}

--- a/lib/src/main/cpp/Terminal.cpp
+++ b/lib/src/main/cpp/Terminal.cpp
@@ -411,6 +411,22 @@ bool Terminal::dispatchCharacter(int modifiers, int codepoint) {
     return true;
 }
 
+void Terminal::startPaste() {
+    std::lock_guard<std::recursive_mutex> lock(mLock);
+    if (!mVt) {
+        return;
+    }
+    vterm_keyboard_start_paste(mVt);
+}
+
+void Terminal::endPaste() {
+    std::lock_guard<std::recursive_mutex> lock(mLock);
+    if (!mVt) {
+        return;
+    }
+    vterm_keyboard_end_paste(mVt);
+}
+
 // Cell run retrieval
 int Terminal::getCellRun(JNIEnv* env, int row, int col, jobject runObject) {
     std::lock_guard<std::recursive_mutex> lock(mLock);
@@ -1235,6 +1251,20 @@ Java_org_connectbot_terminal_TerminalNative_nativeSetBoldHighbright(JNIEnv* /* e
                                                                      jlong ptr, jboolean enabled) {
     auto* term = reinterpret_cast<Terminal*>(ptr);
     return term->setBoldHighbright(enabled ? 1 : 0);
+}
+
+JNIEXPORT void JNICALL
+Java_org_connectbot_terminal_TerminalNative_nativeStartPaste(JNIEnv* /* env */, jobject /* thiz */,
+                                                              jlong ptr) {
+    auto* term = reinterpret_cast<Terminal*>(ptr);
+    term->startPaste();
+}
+
+JNIEXPORT void JNICALL
+Java_org_connectbot_terminal_TerminalNative_nativeEndPaste(JNIEnv* /* env */, jobject /* thiz */,
+                                                            jlong ptr) {
+    auto* term = reinterpret_cast<Terminal*>(ptr);
+    term->endPaste();
 }
 
 } // extern "C"

--- a/lib/src/main/cpp/Terminal.h
+++ b/lib/src/main/cpp/Terminal.h
@@ -60,6 +60,11 @@ public:
     bool dispatchKey(int modifiers, int key);
     bool dispatchCharacter(int modifiers, int codepoint);
 
+    // Bracketed paste bracketing - emits ESC[200~ / ESC[201~ only when
+    // DEC mode 2004 is enabled on the terminal; otherwise a no-op.
+    void startPaste();
+    void endPaste();
+
     // Cell data retrieval for rendering
     int getCellRun(JNIEnv* env, int row, int col, jobject runObject);
 

--- a/lib/src/main/java/org/connectbot/terminal/TerminalEmulator.kt
+++ b/lib/src/main/java/org/connectbot/terminal/TerminalEmulator.kt
@@ -69,6 +69,17 @@ sealed interface TerminalEmulator {
     fun dispatchCharacter(modifiers: Int, codepoint: Int)
 
     /**
+     * Send pasted text to the host as keyboard output, bracketing it with
+     * ESC[200~ / ESC[201~ when the remote side has enabled DEC mode 2004
+     * (bracketed paste). When the mode is off, the text is sent as if each
+     * character were typed, matching historical behavior.
+     *
+     * Code points are dispatched one by one so the host sees UTF-8 bytes;
+     * newlines arrive as literal LF (0x0A) rather than Return keystrokes.
+     */
+    fun paste(text: String)
+
+    /**
      * Clears the terminal emulator screen.
      */
     fun clearScreen()
@@ -382,6 +393,17 @@ internal class TerminalEmulatorImpl(
      */
     override fun dispatchCharacter(modifiers: Int, codepoint: Int) {
         terminalNative.dispatchCharacter(modifiers, codepoint)
+    }
+
+    override fun paste(text: String) {
+        terminalNative.startPaste()
+        var i = 0
+        while (i < text.length) {
+            val cp = text.codePointAt(i)
+            terminalNative.dispatchCharacter(0, cp)
+            i += Character.charCount(cp)
+        }
+        terminalNative.endPaste()
     }
 
     /**

--- a/lib/src/main/java/org/connectbot/terminal/TerminalNative.kt
+++ b/lib/src/main/java/org/connectbot/terminal/TerminalNative.kt
@@ -182,6 +182,26 @@ internal class TerminalNative(callbacks: TerminalCallbacks) : AutoCloseable {
     }
 
     /**
+     * Emit the bracketed-paste start marker (ESC[200~) if DEC mode 2004 is
+     * currently enabled on the terminal. No-op otherwise. The bytes are
+     * delivered to the caller via the onKeyboardInput callback, like any
+     * other keyboard output.
+     */
+    fun startPaste() {
+        checkNotClosed()
+        nativeStartPaste(nativePtr)
+    }
+
+    /**
+     * Emit the bracketed-paste end marker (ESC[201~) if DEC mode 2004 is
+     * currently enabled on the terminal. No-op otherwise.
+     */
+    fun endPaste() {
+        checkNotClosed()
+        nativeEndPaste(nativePtr)
+    }
+
+    /**
      * Close the terminal and release native resources.
      * After calling this, the Terminal instance cannot be used.
      */
@@ -217,6 +237,8 @@ internal class TerminalNative(callbacks: TerminalCallbacks) : AutoCloseable {
     private external fun nativeSetDefaultColors(ptr: Long, fgColor: Int, bgColor: Int): Int
     private external fun nativeGetLineContinuation(ptr: Long, row: Int): Boolean
     private external fun nativeSetBoldHighbright(ptr: Long, enabled: Boolean): Int
+    private external fun nativeStartPaste(ptr: Long)
+    private external fun nativeEndPaste(ptr: Long)
 
     companion object {
         init {


### PR DESCRIPTION
Possibly fixs connectbot/connectbot#2058. 
Expose libvterm's vterm_keyboard_start_paste / end_paste via JNI and add a TerminalEmulator.paste(String) entry point. When the remote side has enabled DEC mode 2004, the pasted text is wrapped in ESC[200~ / ESC[201~; otherwise the text is sent as if typed, so existing callers are unaffected.