### PR TITLE
Keep compose mode active across Enter and Escape

### DIFF
--- a/lib/src/androidTest/java/org/connectbot/terminal/KeyboardHandlerTest.kt
+++ b/lib/src/androidTest/java/org/connectbot/terminal/KeyboardHandlerTest.kt
@@ -230,16 +230,34 @@ class KeyboardHandlerTest {
     }
 
     @Test
-    fun testComposeModeEscapeCancels() {
+    fun testComposeModeEscapeCancelsCompositionInProgress() {
         val composeMode = ComposeMode()
         composeMode.activate()
         keyboardHandler.composeMode = composeMode
+        keyboardHandler.onInputProcessed = { inputProcessedCallCount++ }
 
         keyboardHandler.onKeyEvent(createKeyEvent(Key.A, KeyEventType.KeyDown))
         keyboardHandler.onKeyEvent(createKeyEvent(Key.Escape, KeyEventType.KeyDown))
 
-        assertFalse(composeMode.isActive)
+        assertTrue(composeMode.isActive)
         assertEquals("", composeMode.buffer)
+        // Esc with non-empty buffer just cancels the composition; no terminal dispatch.
+        assertEquals(0, inputProcessedCallCount)
+    }
+
+    @Test
+    fun testComposeModeEscapePassesThroughWhenBufferEmpty() {
+        val composeMode = ComposeMode()
+        composeMode.activate()
+        keyboardHandler.composeMode = composeMode
+        keyboardHandler.onInputProcessed = { inputProcessedCallCount++ }
+
+        keyboardHandler.onKeyEvent(createKeyEvent(Key.Escape, KeyEventType.KeyDown))
+
+        assertTrue(composeMode.isActive)
+        assertEquals("", composeMode.buffer)
+        // Esc with empty buffer is dispatched to the terminal as a real Escape key.
+        assertEquals(1, inputProcessedCallCount)
     }
 
     @Test
@@ -253,7 +271,8 @@ class KeyboardHandlerTest {
         keyboardHandler.onKeyEvent(createKeyEvent(Key.B, KeyEventType.KeyDown))
         keyboardHandler.onKeyEvent(createKeyEvent(Key.Enter, KeyEventType.KeyDown))
 
-        assertFalse(composeMode.isActive)
+        assertTrue(composeMode.isActive)
+        assertEquals("", composeMode.buffer)
         assertEquals(1, inputProcessedCallCount)
     }
 

--- a/lib/src/main/java/org/connectbot/terminal/ComposeMode.kt
+++ b/lib/src/main/java/org/connectbot/terminal/ComposeMode.kt
@@ -60,20 +60,24 @@ internal class ComposeMode {
     }
 
     /**
-     * Commit the composed text. Returns the buffer text and deactivates compose mode.
-     * Returns null if inactive or buffer is empty.
+     * Commit the composed text. Returns the buffer text and clears it, keeping compose
+     * mode active so subsequent input continues to be buffered. Returns null if inactive
+     * or buffer is empty.
      */
     fun commit(): String? {
-        if (!isActive || buffer.isEmpty()) {
-            deactivate()
-            return null
-        }
+        if (!isActive) return null
+        if (buffer.isEmpty()) return null
         val text = buffer
-        deactivate()
+        buffer = ""
         return text
     }
 
+    /**
+     * Drop the current composition without committing. Compose mode remains active so
+     * the user can keep composing; only the explicit toggle (deactivate) leaves the mode.
+     */
     fun cancel() {
-        deactivate()
+        if (!isActive) return
+        buffer = ""
     }
 }

--- a/lib/src/main/java/org/connectbot/terminal/KeyboardHandler.kt
+++ b/lib/src/main/java/org/connectbot/terminal/KeyboardHandler.kt
@@ -93,13 +93,30 @@ internal class KeyboardHandler(
         if (compose != null && compose.isActive) {
             when (key) {
                 Key.Enter -> {
+                    // Flush any IME-composed text, then dispatch a real Enter so the shell
+                    // sees a newline. Compose mode stays active (sticky toggle).
                     val text = compose.commit()
                     text?.codePoints()?.forEach { codepoint ->
                         terminalEmulator.dispatchCharacter(0, codepoint)
                     }
+                    val modifiers = buildModifierMask(ctrl, alt, shift)
+                    terminalEmulator.dispatchKey(modifiers, VTermKey.ENTER)
+                    modifierManager?.clearTransients()
                     onInputProcessed?.invoke()
                 }
-                Key.Escape -> compose.cancel()
+                Key.Escape -> {
+                    // If a composition is in progress, Esc just cancels it (vim-like). With
+                    // an empty buffer, Esc passes through to the shell. Compose mode stays
+                    // active either way.
+                    if (compose.buffer.isNotEmpty()) {
+                        compose.cancel()
+                    } else {
+                        val modifiers = buildModifierMask(ctrl, alt, shift)
+                        terminalEmulator.dispatchKey(modifiers, VTermKey.ESCAPE)
+                        modifierManager?.clearTransients()
+                        onInputProcessed?.invoke()
+                    }
+                }
                 Key.Backspace -> compose.deleteLastChar()
                 else -> {
                     if (!ctrl && !alt) {

--- a/lib/src/main/java/org/connectbot/terminal/Terminal.kt
+++ b/lib/src/main/java/org/connectbot/terminal/Terminal.kt
@@ -588,7 +588,7 @@ fun TerminalWithAccessibility(
             }
 
             override fun stopComposeMode() {
-                composeMode.cancel()
+                composeMode.deactivate()
             }
 
             override fun toggleComposeMode() {

--- a/lib/src/test/java/org/connectbot/terminal/ComposeModeTest.kt
+++ b/lib/src/test/java/org/connectbot/terminal/ComposeModeTest.kt
@@ -140,7 +140,7 @@ class ComposeModeTest {
         val result = composeMode.commit()
 
         assertEquals("hello", result)
-        assertFalse(composeMode.isActive)
+        assertTrue(composeMode.isActive)
         assertEquals("", composeMode.buffer)
     }
 
@@ -150,7 +150,7 @@ class ComposeModeTest {
         val result = composeMode.commit()
 
         assertNull(result)
-        assertFalse(composeMode.isActive)
+        assertTrue(composeMode.isActive)
     }
 
     @Test
@@ -167,7 +167,7 @@ class ComposeModeTest {
         composeMode.appendText("hello")
         composeMode.cancel()
 
-        assertFalse(composeMode.isActive)
+        assertTrue(composeMode.isActive)
         assertEquals("", composeMode.buffer)
     }
 


### PR DESCRIPTION
ComposeMode.commit() and cancel() now only flush the local buffer and leave isActive untouched, so a sticky compose-mode toggle in the host app survives committing or aborting a single composition. The explicit toggle-off path now goes through deactivate() (Terminal.stopComposeMode updated accordingly), which is still the only way to leave the mode.

KeyboardHandler.onKeyEvent now also lets the underlying Enter/Escape keystrokes reach the terminal in compose mode: Enter flushes any IME buffer and then dispatches a real Enter so the shell sees the newline, and Escape with an empty buffer is dispatched as a real Esc (Esc with a non-empty buffer still just cancels the composition, vim-style). This avoids the IME restart churn caused by toggling compose mode on and off around every commit.