### PR TITLE
Sticky compose mode

### DIFF
--- a/lib/src/main/java/org/connectbot/terminal/ComposeMode.kt
+++ b/lib/src/main/java/org/connectbot/terminal/ComposeMode.kt
@@ -60,20 +60,24 @@ internal class ComposeMode {
     }
 
     /**
-     * Commit the composed text. Returns the buffer text and deactivates compose mode.
-     * Returns null if inactive or buffer is empty.
+     * Commit the composed text. Returns the buffer text and clears it, keeping compose
+     * mode active so subsequent input continues to be buffered. Returns null if inactive
+     * or buffer is empty.
      */
     fun commit(): String? {
-        if (!isActive || buffer.isEmpty()) {
-            deactivate()
-            return null
-        }
+        if (!isActive) return null
+        if (buffer.isEmpty()) return null
         val text = buffer
-        deactivate()
+        buffer = ""
         return text
     }
 
+    /**
+     * Drop the current composition without committing. Compose mode remains active so
+     * the user can keep composing; only the explicit toggle (deactivate) leaves the mode.
+     */
     fun cancel() {
-        deactivate()
+        if (!isActive) return
+        buffer = ""
     }
 }

--- a/lib/src/main/java/org/connectbot/terminal/ImeInputView.kt
+++ b/lib/src/main/java/org/connectbot/terminal/ImeInputView.kt
@@ -338,7 +338,7 @@ internal class ImeInputView(
                 if (previousComposingText.isNotEmpty()) {
                     sendBackspaces(previousComposingText.length)
                 }
-                sendTextInput(committedText)
+                keyboardHandler.onCommittedText(committedText)
             }
             composingText = ""
             editable?.clear()

--- a/lib/src/main/java/org/connectbot/terminal/ImeInputView.kt
+++ b/lib/src/main/java/org/connectbot/terminal/ImeInputView.kt
@@ -47,7 +47,7 @@ internal class ImeInputView(
             inputMethodManager.updateSelection(view, selStart, selEnd, candidatesStart, candidatesEnd)
         },
     internal val onRestartInput: (view: View) -> Unit =
-        { view -> inputMethodManager.restartInput(view) }
+        { view -> inputMethodManager.restartInput(view) },
 ) : View(context) {
 
     init {

--- a/lib/src/main/java/org/connectbot/terminal/ImeInputView.kt
+++ b/lib/src/main/java/org/connectbot/terminal/ImeInputView.kt
@@ -46,6 +46,8 @@ internal class ImeInputView(
         { view, selStart, selEnd, candidatesStart, candidatesEnd ->
             inputMethodManager.updateSelection(view, selStart, selEnd, candidatesStart, candidatesEnd)
         },
+    internal val onRestartInput: (view: View) -> Unit =
+        { view -> inputMethodManager.restartInput(view) }
 ) : View(context) {
 
     init {
@@ -58,7 +60,7 @@ internal class ImeInputView(
             if (field == value) return
             field = value
             if (windowToken != null) {
-                inputMethodManager.restartInput(this)
+                onRestartInput(this)
             }
         }
 
@@ -142,6 +144,10 @@ internal class ImeInputView(
         onUpdateSelection(this, 0, 0, -1, -1)
     }
 
+    private fun restartInputSoon() {
+        onRestartInput(this)
+    }
+
     /**
      * Custom InputConnection that handles backspace and other special keys for terminal input.
      */
@@ -151,11 +157,15 @@ internal class ImeInputView(
     ) : BaseInputConnection(targetView, fullEditor) {
 
         private var composingText: String = ""
+        private var awaitingPostEnterCommitReplay: Boolean = false
 
         override fun setComposingText(text: CharSequence?, newCursorPosition: Int): Boolean {
             if (!fullEditor) return super.setComposingText(text, newCursorPosition)
 
             val newText = text?.toString() ?: ""
+            if (awaitingPostEnterCommitReplay && newText.isNotEmpty()) {
+                awaitingPostEnterCommitReplay = false
+            }
             super.setComposingText(text, newCursorPosition)
 
             if (newText == composingText) {
@@ -238,6 +248,7 @@ internal class ImeInputView(
                 // Gboard does not accumulate terminal input as suggestion candidates.
                 val result = this@ImeInputView.dispatchKeyEvent(event)
                 if (event.action == KeyEvent.ACTION_DOWN) {
+                    awaitingPostEnterCommitReplay = event.keyCode == KeyEvent.KEYCODE_ENTER
                     editable?.clear()
                     onUpdateSelection(this@ImeInputView, 0, 0, -1, -1)
                 }
@@ -281,6 +292,22 @@ internal class ImeInputView(
             val previousComposingText = composingText
             super.commitText(text, newCursorPosition)
 
+            if (awaitingPostEnterCommitReplay &&
+                previousComposingText.isNotEmpty() &&
+                committedText == previousComposingText
+            ) {
+                awaitingPostEnterCommitReplay = false
+                composingText = ""
+                editable?.clear()
+                onUpdateSelection(this@ImeInputView, 0, 0, -1, -1)
+                // Some IMEs replay the just-submitted composition after Enter. Ignore that
+                // replay so the shell text stays committed, then force the IME to drop the
+                // stale composing span that would otherwise keep the green overlay alive.
+                restartInputSoon()
+                return true
+            }
+
+            awaitingPostEnterCommitReplay = false
             if (committedText.isNotEmpty()) {
                 if (previousComposingText.isNotEmpty()) {
                     sendBackspaces(previousComposingText.length)

--- a/lib/src/main/java/org/connectbot/terminal/ImeInputView.kt
+++ b/lib/src/main/java/org/connectbot/terminal/ImeInputView.kt
@@ -158,13 +158,32 @@ internal class ImeInputView(
 
         private var composingText: String = ""
         private var awaitingPostEnterCommitReplay: Boolean = false
+        private var postEnterSubmittedText: String? = null
 
         override fun setComposingText(text: CharSequence?, newCursorPosition: Int): Boolean {
             if (!fullEditor) return super.setComposingText(text, newCursorPosition)
 
             val newText = text?.toString() ?: ""
+            if (awaitingPostEnterCommitReplay &&
+                newText.isNotEmpty() &&
+                postEnterSubmittedText != null &&
+                newText == postEnterSubmittedText
+            ) {
+                super.setComposingText(text, newCursorPosition)
+                awaitingPostEnterCommitReplay = false
+                postEnterSubmittedText = null
+                composingText = ""
+                editable?.clear()
+                onUpdateSelection(this@ImeInputView, 0, 0, -1, -1)
+                // Some IMEs replay the just-submitted composition through setComposingText()
+                // after Enter. Ignore that replay so the compose overlay stays cleared.
+                restartInputSoon()
+                return true
+            }
+
             if (awaitingPostEnterCommitReplay && newText.isNotEmpty()) {
                 awaitingPostEnterCommitReplay = false
+                postEnterSubmittedText = null
             }
             super.setComposingText(text, newCursorPosition)
 
@@ -249,6 +268,11 @@ internal class ImeInputView(
                 val result = this@ImeInputView.dispatchKeyEvent(event)
                 if (event.action == KeyEvent.ACTION_DOWN) {
                     awaitingPostEnterCommitReplay = event.keyCode == KeyEvent.KEYCODE_ENTER
+                    postEnterSubmittedText = if (awaitingPostEnterCommitReplay) {
+                        composingText.takeIf { it.isNotEmpty() }
+                    } else {
+                        null
+                    }
                     editable?.clear()
                     onUpdateSelection(this@ImeInputView, 0, 0, -1, -1)
                 }
@@ -293,10 +317,11 @@ internal class ImeInputView(
             super.commitText(text, newCursorPosition)
 
             if (awaitingPostEnterCommitReplay &&
-                previousComposingText.isNotEmpty() &&
-                committedText == previousComposingText
+                postEnterSubmittedText != null &&
+                committedText == postEnterSubmittedText
             ) {
                 awaitingPostEnterCommitReplay = false
+                postEnterSubmittedText = null
                 composingText = ""
                 editable?.clear()
                 onUpdateSelection(this@ImeInputView, 0, 0, -1, -1)
@@ -308,6 +333,7 @@ internal class ImeInputView(
             }
 
             awaitingPostEnterCommitReplay = false
+            postEnterSubmittedText = null
             if (committedText.isNotEmpty()) {
                 if (previousComposingText.isNotEmpty()) {
                     sendBackspaces(previousComposingText.length)

--- a/lib/src/main/java/org/connectbot/terminal/ImeInputView.kt
+++ b/lib/src/main/java/org/connectbot/terminal/ImeInputView.kt
@@ -262,17 +262,20 @@ internal class ImeInputView(
 
         override fun sendKeyEvent(event: KeyEvent): Boolean {
             if (fullEditor) {
+                val isKeyDown = event.action == KeyEvent.ACTION_DOWN
+                val postEnterSubmittedBeforeDispatch = if (isKeyDown && event.keyCode == KeyEvent.KEYCODE_ENTER) {
+                    composingText.takeIf { it.isNotEmpty() }
+                } else {
+                    null
+                }
+
                 // Compose mode (TYPE_CLASS_TEXT): route through dispatchKeyEvent so the
                 // setOnKeyListener chain handles it. Clear the editable buffer afterward so
                 // Gboard does not accumulate terminal input as suggestion candidates.
                 val result = this@ImeInputView.dispatchKeyEvent(event)
-                if (event.action == KeyEvent.ACTION_DOWN) {
+                if (isKeyDown) {
                     awaitingPostEnterCommitReplay = event.keyCode == KeyEvent.KEYCODE_ENTER
-                    postEnterSubmittedText = if (awaitingPostEnterCommitReplay) {
-                        composingText.takeIf { it.isNotEmpty() }
-                    } else {
-                        null
-                    }
+                    postEnterSubmittedText = postEnterSubmittedBeforeDispatch
                     editable?.clear()
                     onUpdateSelection(this@ImeInputView, 0, 0, -1, -1)
                 }

--- a/lib/src/main/java/org/connectbot/terminal/KeyboardHandler.kt
+++ b/lib/src/main/java/org/connectbot/terminal/KeyboardHandler.kt
@@ -335,6 +335,43 @@ internal class KeyboardHandler(
     }
 
     /**
+     * Dispatch finalized IME text directly to the terminal, bypassing composeMode.buffer.
+     *
+     * setComposingText() updates the local compose overlay while the IME is still composing.
+     * Once the IME calls commitText(), that text is final and should become terminal input
+     * immediately rather than staying attached to the sticky compose buffer.
+     */
+    fun onCommittedText(text: String) {
+        if (text.isEmpty()) return
+
+        val normalized = if (Normalizer.isNormalized(text, Normalizer.Form.NFC)) text
+                         else Normalizer.normalize(text, Normalizer.Form.NFC)
+        val modifiers = getModifierMask()
+
+        var index = 0
+        while (index < normalized.length) {
+            when (val ch = normalized[index]) {
+                '\n' -> {
+                    terminalEmulator.dispatchKey(modifiers, VTermKey.ENTER)
+                    index += 1
+                }
+                '\r' -> {
+                    terminalEmulator.dispatchKey(modifiers, VTermKey.ENTER)
+                    index += if (index + 1 < normalized.length && normalized[index + 1] == '\n') 2 else 1
+                }
+                else -> {
+                    val codepoint = normalized.codePointAt(index)
+                    terminalEmulator.dispatchCharacter(modifiers, codepoint)
+                    index += Character.charCount(codepoint)
+                }
+            }
+        }
+
+        modifierManager?.clearTransients()
+        onInputProcessed?.invoke()
+    }
+
+    /**
      * Build VTerm modifier mask.
      * Bit 0: Shift
      * Bit 1: Alt

--- a/lib/src/main/java/org/connectbot/terminal/KeyboardHandler.kt
+++ b/lib/src/main/java/org/connectbot/terminal/KeyboardHandler.kt
@@ -141,6 +141,7 @@ internal class KeyboardHandler(
                     modifierManager?.clearTransients()
                     onInputProcessed?.invoke()
                 }
+
                 Key.Escape -> {
                     // If a composition is in progress, Esc just cancels it (vim-like). With
                     // an empty buffer, Esc passes through to the shell. Compose mode stays
@@ -154,6 +155,7 @@ internal class KeyboardHandler(
                         onInputProcessed?.invoke()
                     }
                 }
+
                 Key.Backspace -> {
                     // With a composition in progress, Backspace edits the buffer. With an
                     // empty buffer it passes through so users can still delete characters
@@ -167,6 +169,7 @@ internal class KeyboardHandler(
                         onInputProcessed?.invoke()
                     }
                 }
+
                 else -> {
                     if (!ctrl && !event.isAltPressed) {
                         val codepoint = getCodePointFromKeyEvent(event)
@@ -340,8 +343,11 @@ internal class KeyboardHandler(
     fun onCommittedText(text: String) {
         if (text.isEmpty()) return
 
-        val normalized = if (Normalizer.isNormalized(text, Normalizer.Form.NFC)) text
-                         else Normalizer.normalize(text, Normalizer.Form.NFC)
+        val normalized = if (Normalizer.isNormalized(text, Normalizer.Form.NFC)) {
+            text
+        } else {
+            Normalizer.normalize(text, Normalizer.Form.NFC)
+        }
         val modifiers = getModifierMask()
 
         var index = 0
@@ -351,10 +357,12 @@ internal class KeyboardHandler(
                     terminalEmulator.dispatchKey(modifiers, VTermKey.ENTER)
                     index += 1
                 }
+
                 '\r' -> {
                     terminalEmulator.dispatchKey(modifiers, VTermKey.ENTER)
                     index += if (index + 1 < normalized.length && normalized[index + 1] == '\n') 2 else 1
                 }
+
                 else -> {
                     val codepoint = normalized.codePointAt(index)
                     terminalEmulator.dispatchCharacter(modifiers, codepoint)

--- a/lib/src/main/java/org/connectbot/terminal/KeyboardHandler.kt
+++ b/lib/src/main/java/org/connectbot/terminal/KeyboardHandler.kt
@@ -127,17 +127,43 @@ internal class KeyboardHandler(
         if (compose != null && compose.isActive) {
             when (key) {
                 Key.Enter -> {
+                    // Flush any IME-composed text, then dispatch a real Enter so the shell
+                    // sees a newline. Compose mode stays active (sticky toggle).
                     val text = compose.commit()
                     text?.codePoints()?.forEach { codepoint ->
                         terminalEmulator.dispatchCharacter(0, codepoint)
                     }
+                    val modifiers = buildModifierMask(ctrl, alt, shift)
+                    terminalEmulator.dispatchKey(modifiers, VTermKey.ENTER)
+                    modifierManager?.clearTransients()
                     onInputProcessed?.invoke()
                 }
-
-                Key.Escape -> compose.cancel()
-
-                Key.Backspace -> compose.deleteLastChar()
-
+                Key.Escape -> {
+                    // If a composition is in progress, Esc just cancels it (vim-like). With
+                    // an empty buffer, Esc passes through to the shell. Compose mode stays
+                    // active either way.
+                    if (compose.buffer.isNotEmpty()) {
+                        compose.cancel()
+                    } else {
+                        val modifiers = buildModifierMask(ctrl, alt, shift)
+                        terminalEmulator.dispatchKey(modifiers, VTermKey.ESCAPE)
+                        modifierManager?.clearTransients()
+                        onInputProcessed?.invoke()
+                    }
+                }
+                Key.Backspace -> {
+                    // With a composition in progress, Backspace edits the buffer. With an
+                    // empty buffer it passes through so users can still delete characters
+                    // that were typed into the shell before entering compose mode.
+                    if (compose.buffer.isNotEmpty()) {
+                        compose.deleteLastChar()
+                    } else {
+                        val modifiers = buildModifierMask(ctrl, alt, shift)
+                        terminalEmulator.dispatchKey(modifiers, VTermKey.BACKSPACE)
+                        modifierManager?.clearTransients()
+                        onInputProcessed?.invoke()
+                    }
+                }
                 else -> {
                     if (!ctrl && !event.isAltPressed) {
                         val codepoint = getCodePointFromKeyEvent(event)

--- a/lib/src/main/java/org/connectbot/terminal/KeyboardHandler.kt
+++ b/lib/src/main/java/org/connectbot/terminal/KeyboardHandler.kt
@@ -121,6 +121,9 @@ internal class KeyboardHandler(
         val key = event.key
         val ctrl = event.isCtrlPressed
         val shift = event.isShiftPressed
+        val modifierState = resolveEventModifierState(event)
+        val alt = modifierState.alt
+        val stripAltGr = modifierState.stripAltGr
 
         // If compose mode is active, intercept all input
         val compose = composeMode
@@ -228,13 +231,6 @@ internal class KeyboardHandler(
         }
 
         // Determine whether right-alt counts as a terminal modifier or a character selector.
-        val rightAltPressed = nativeEvent.hasModifiers(AndroidKeyEvent.META_ALT_RIGHT_ON)
-        val rightAltIsMeta = rightAltPressed && rightAltMode == RightAltMode.Meta
-        val leftAltPressed = nativeEvent.hasModifiers(AndroidKeyEvent.META_ALT_LEFT_ON) ||
-            (!rightAltPressed && nativeEvent.metaState and AndroidKeyEvent.META_ALT_ON != 0)
-        val alt = leftAltPressed || rightAltIsMeta
-        val stripAltGr = rightAltIsMeta
-
         // When DelKeyMode.Backspace is active, swap the byte sequences:
         // Backspace → ^H (0x08), Delete → DEL (0x7f).
         if (delKeyMode is DelKeyMode.Backspace) {
@@ -383,6 +379,19 @@ internal class KeyboardHandler(
         if (alt) mask = mask or 2
         if (ctrl) mask = mask or 4
         return mask
+    }
+
+    private fun resolveEventModifierState(event: ComposeKeyEvent): EventModifierState {
+        val nativeEvent = event.nativeKeyEvent
+        val rightAltPressed = nativeEvent.hasModifiers(AndroidKeyEvent.META_ALT_RIGHT_ON)
+        val rightAltIsMeta = rightAltPressed && rightAltMode == RightAltMode.Meta
+        val leftAltPressed = nativeEvent.hasModifiers(AndroidKeyEvent.META_ALT_LEFT_ON) ||
+            (!rightAltPressed && nativeEvent.metaState and AndroidKeyEvent.META_ALT_ON != 0)
+
+        return EventModifierState(
+            alt = leftAltPressed || rightAltIsMeta,
+            stripAltGr = rightAltIsMeta,
+        )
     }
 
     /**
@@ -593,6 +602,11 @@ internal class KeyboardHandler(
         else -> null
     }
 }
+
+private data class EventModifierState(
+    val alt: Boolean,
+    val stripAltGr: Boolean,
+)
 
 /**
  * VTerm key codes from libvterm.

--- a/lib/src/main/java/org/connectbot/terminal/KeyboardHandler.kt
+++ b/lib/src/main/java/org/connectbot/terminal/KeyboardHandler.kt
@@ -164,7 +164,11 @@ internal class KeyboardHandler(
                         compose.deleteLastChar()
                     } else {
                         val modifiers = buildModifierMask(ctrl, alt, shift)
-                        terminalEmulator.dispatchKey(modifiers, VTermKey.BACKSPACE)
+                        if (delKeyMode is DelKeyMode.Backspace) {
+                            terminalEmulator.dispatchCharacter(modifiers, 0x08)
+                        } else {
+                            terminalEmulator.dispatchKey(modifiers, VTermKey.BACKSPACE)
+                        }
                         modifierManager?.clearTransients()
                         onInputProcessed?.invoke()
                     }
@@ -233,7 +237,6 @@ internal class KeyboardHandler(
             }
         }
 
-        // Determine whether right-alt counts as a terminal modifier or a character selector.
         // When DelKeyMode.Backspace is active, swap the byte sequences:
         // Backspace → ^H (0x08), Delete → DEL (0x7f).
         if (delKeyMode is DelKeyMode.Backspace) {

--- a/lib/src/main/java/org/connectbot/terminal/Terminal.kt
+++ b/lib/src/main/java/org/connectbot/terminal/Terminal.kt
@@ -2247,7 +2247,11 @@ private fun codepointColumns(codepoint: Int): Int {
     val eastAsianWidth = UCharacter.getIntPropertyValue(codepoint, UProperty.EAST_ASIAN_WIDTH)
     return if (eastAsianWidth == UCharacter.EastAsianWidth.FULLWIDTH ||
         eastAsianWidth == UCharacter.EastAsianWidth.WIDE
-    ) 2 else 1
+    ) {
+        2
+    } else {
+        1
+    }
 }
 
 private fun String.visualColumnWidth(): Int {

--- a/lib/src/main/java/org/connectbot/terminal/Terminal.kt
+++ b/lib/src/main/java/org/connectbot/terminal/Terminal.kt
@@ -21,6 +21,8 @@ import android.content.Intent
 import android.graphics.Paint
 import android.graphics.Path
 import android.graphics.Typeface
+import android.icu.lang.UCharacter
+import android.icu.lang.UProperty
 import android.text.TextPaint
 import android.util.Log
 import androidx.annotation.VisibleForTesting
@@ -648,7 +650,12 @@ internal fun TerminalWithAccessibility(
             }
 
             override fun stopComposeMode() {
-                composeMode.cancel()
+                // Flush any in-flight IME composition into the terminal before leaving
+                // compose mode, so the user's typing isn't silently dropped on toggle off.
+                composeMode.commit()?.codePoints()?.forEach { codepoint ->
+                    terminalEmulator.dispatchCharacter(0, codepoint)
+                }
+                composeMode.deactivate()
             }
 
             override fun toggleComposeMode() {
@@ -2171,14 +2178,19 @@ private fun DrawScope.drawComposeOverlay(
     val y = cursorRow * charHeight
     val availableCols = totalCols - cursorCol
 
-    // Determine displayed text with slide-left behavior
-    val displayText = if (buffer.length > availableCols) {
-        "\u2026" + buffer.takeLast(availableCols - 1)
-    } else {
-        buffer
-    }
+    // No active composition — nothing to draw. Suppressing the empty-buffer block here
+    // avoids a stray green square sitting next to (or briefly over) just-committed chars
+    // after Enter while the terminal snapshot catches up with the cursor advance.
+    if (buffer.isEmpty()) return
 
-    val displayWidth = displayText.length * charWidth
+    // Truncation is column-based (CJK fullwidth/wide chars take 2 columns) so the buffer
+    // is clipped to what fits between the cursor and the right edge of the row. The pixel
+    // width, however, comes from the paint that actually draws the text — fonts don't
+    // always render "あ" at exactly 2 × measureText("M"), and using column math for pixels
+    // makes the trailing cursor drift further past the glyphs as the buffer grows.
+    val displayText = truncateForOverlay(buffer, availableCols)
+    if (displayText.isEmpty()) return
+    val displayWidth = textPaint.measureText(displayText)
 
     // Draw background
     drawRect(
@@ -2216,13 +2228,64 @@ private fun DrawScope.drawComposeOverlay(
     }
 
     // Draw cursor bar at end of displayed text
-    val cursorX = x + displayText.length * charWidth
+    val cursorX = x + displayWidth
     drawRect(
         color = Color.White,
         topLeft = Offset(cursorX, y),
         size = Size(COMPOSE_CURSOR_BAR_WIDTH, charHeight),
         alpha = CURSOR_LINE_ALPHA,
     )
+}
+
+/**
+ * Visual column width of a single codepoint. Fullwidth/wide East Asian characters
+ * (kanji, kana, hangul, fullwidth ASCII, etc.) occupy two terminal columns; everything
+ * else occupies one. Combining marks aren't special-cased here because the IME-composed
+ * buffer rarely contains them on their own; if needed they can be treated as zero-width.
+ */
+private fun codepointColumns(codepoint: Int): Int {
+    val eastAsianWidth = UCharacter.getIntPropertyValue(codepoint, UProperty.EAST_ASIAN_WIDTH)
+    return if (eastAsianWidth == UCharacter.EastAsianWidth.FULLWIDTH ||
+        eastAsianWidth == UCharacter.EastAsianWidth.WIDE
+    ) 2 else 1
+}
+
+private fun String.visualColumnWidth(): Int {
+    var total = 0
+    var i = 0
+    while (i < length) {
+        val cp = codePointAt(i)
+        total += codepointColumns(cp)
+        i += Character.charCount(cp)
+    }
+    return total
+}
+
+/**
+ * Trim the buffer so its visual column width fits in [availableCols], keeping the right
+ * end of the buffer (most recent characters) and prefixing an ellipsis when truncating.
+ */
+private fun truncateForOverlay(buffer: String, availableCols: Int): String {
+    if (availableCols <= 0) return ""
+    if (buffer.visualColumnWidth() <= availableCols) return buffer
+
+    // Walk codepoints from the right, accumulating width up to availableCols - 1 (one
+    // column reserved for the leading ellipsis).
+    val budget = availableCols - 1
+    val codepoints = mutableListOf<Int>()
+    var taken = 0
+    var i = buffer.length
+    while (i > 0) {
+        val cp = buffer.codePointBefore(i)
+        val w = codepointColumns(cp)
+        if (taken + w > budget) break
+        codepoints.add(0, cp)
+        taken += w
+        i -= Character.charCount(cp)
+    }
+    val builder = StringBuilder("\u2026")
+    codepoints.forEach { builder.appendCodePoint(it) }
+    return builder.toString()
 }
 
 /**

--- a/lib/src/test/java/org/connectbot/terminal/ComposeModeTest.kt
+++ b/lib/src/test/java/org/connectbot/terminal/ComposeModeTest.kt
@@ -140,7 +140,7 @@ class ComposeModeTest {
         val result = composeMode.commit()
 
         assertEquals("hello", result)
-        assertFalse(composeMode.isActive)
+        assertTrue(composeMode.isActive)
         assertEquals("", composeMode.buffer)
     }
 
@@ -150,7 +150,7 @@ class ComposeModeTest {
         val result = composeMode.commit()
 
         assertNull(result)
-        assertFalse(composeMode.isActive)
+        assertTrue(composeMode.isActive)
     }
 
     @Test
@@ -167,7 +167,7 @@ class ComposeModeTest {
         composeMode.appendText("hello")
         composeMode.cancel()
 
-        assertFalse(composeMode.isActive)
+        assertTrue(composeMode.isActive)
         assertEquals("", composeMode.buffer)
     }
 

--- a/lib/src/test/java/org/connectbot/terminal/ImeInputViewTest.kt
+++ b/lib/src/test/java/org/connectbot/terminal/ImeInputViewTest.kt
@@ -356,6 +356,41 @@ class ImeInputViewTest {
         assertEquals("x", effectiveText(outputs))
     }
 
+    @Test
+    fun testCommittedJapaneseTextLeavesComposeBufferImmediately() {
+        val capture = createComposeReplayCapture()
+
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            capture.ic.setComposingText("a", 1)
+            capture.ic.setComposingText("あ", 1)
+            capture.ic.commitText("あ", 1)
+        }
+        drainMainLooper()
+
+        val received = capture.outputs.flatMap { it.toList() }.toByteArray().toString(Charsets.UTF_8)
+        assertEquals("あ", received)
+        assertEquals("", capture.composeMode.buffer)
+        assertEquals(0, capture.restartRequests.size)
+    }
+
+    @Test
+    fun testSpaceAfterCommittedJapaneseTextStartsFreshComposition() {
+        val capture = createComposeReplayCapture()
+
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            capture.ic.setComposingText("a", 1)
+            capture.ic.setComposingText("あ", 1)
+            capture.ic.commitText("あ", 1)
+            capture.ic.setComposingText(" ", 1)
+        }
+        drainMainLooper()
+
+        val received = capture.outputs.flatMap { it.toList() }.toByteArray().toString(Charsets.UTF_8)
+        assertEquals("あ", received)
+        assertEquals(" ", capture.composeMode.buffer)
+        assertEquals(0, capture.restartRequests.size)
+    }
+
     // === Unicode precomposition (NFC normalization) ===
 
     /**

--- a/lib/src/test/java/org/connectbot/terminal/ImeInputViewTest.kt
+++ b/lib/src/test/java/org/connectbot/terminal/ImeInputViewTest.kt
@@ -265,7 +265,7 @@ class ImeInputViewTest {
         val ic: InputConnection,
         val outputs: MutableList<ByteArray>,
         val composeMode: ComposeMode,
-        val restartRequests: MutableList<View>
+        val restartRequests: MutableList<View>,
     )
 
     private fun createComposeReplayCapture(): ComposeReplayCapture {
@@ -275,7 +275,7 @@ class ImeInputViewTest {
         val emulator = TerminalEmulatorFactory.create(
             initialRows = 24,
             initialCols = 80,
-            onKeyboardInput = { data -> outputs.add(data.copyOf()) }
+            onKeyboardInput = { data -> outputs.add(data.copyOf()) },
         )
         val handler = KeyboardHandler(emulator).also { it.composeMode = composeMode }
         var ic: InputConnection? = null
@@ -284,7 +284,7 @@ class ImeInputViewTest {
                 context = context,
                 keyboardHandler = handler,
                 inputMethodManager = noOpImm,
-                onRestartInput = { restartRequests.add(it) }
+                onRestartInput = { restartRequests.add(it) },
             ).also { v ->
                 v.isComposeModeActive = true
                 v.setOnKeyListener { _, _, event ->

--- a/lib/src/test/java/org/connectbot/terminal/ImeInputViewTest.kt
+++ b/lib/src/test/java/org/connectbot/terminal/ImeInputViewTest.kt
@@ -261,6 +261,42 @@ class ImeInputViewTest {
         return ic!! to outputs
     }
 
+    private data class ComposeReplayCapture(
+        val ic: InputConnection,
+        val outputs: MutableList<ByteArray>,
+        val composeMode: ComposeMode,
+        val restartRequests: MutableList<View>
+    )
+
+    private fun createComposeReplayCapture(): ComposeReplayCapture {
+        val outputs = mutableListOf<ByteArray>()
+        val restartRequests = mutableListOf<View>()
+        val composeMode = ComposeMode().also { it.activate() }
+        val emulator = TerminalEmulatorFactory.create(
+            initialRows = 24,
+            initialCols = 80,
+            onKeyboardInput = { data -> outputs.add(data.copyOf()) }
+        )
+        val handler = KeyboardHandler(emulator).also { it.composeMode = composeMode }
+        var ic: InputConnection? = null
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            val view = ImeInputView(
+                context = context,
+                keyboardHandler = handler,
+                inputMethodManager = noOpImm,
+                onRestartInput = { restartRequests.add(it) }
+            ).also { v ->
+                v.isComposeModeActive = true
+                v.setOnKeyListener { _, _, event ->
+                    if (event.action == KeyEvent.ACTION_DOWN) v.resetImeBuffer()
+                    handler.onKeyEvent(androidx.compose.ui.input.key.KeyEvent(event))
+                }
+            }
+            ic = view.onCreateInputConnection(EditorInfo())
+        }
+        return ComposeReplayCapture(ic!!, outputs, composeMode, restartRequests)
+    }
+
     /**
      * Compute the effective text from captured keyboard output by applying
      * BS (0x08) and DEL (0x7F) as character erasure operations.
@@ -380,6 +416,42 @@ class ImeInputViewTest {
         drainMainLooper()
         val received = outputs.flatMap { it.toList() }.toByteArray().toString(Charsets.UTF_8)
         assertEquals(emoji, received)
+    }
+
+    @Test
+    fun testTrailingCommitAfterEnterDoesNotDeleteSubmittedJapaneseText() {
+        val capture = createComposeReplayCapture()
+
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            capture.ic.setComposingText("a", 1)
+            capture.ic.setComposingText("あ", 1)
+            capture.ic.sendKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_ENTER))
+            capture.ic.commitText("あ", 1)
+        }
+        drainMainLooper()
+
+        val received = capture.outputs.flatMap { it.toList() }.toByteArray()
+        assertTrue("Trailing replay emitted DEL and removed submitted text", !received.contains(0x7F.toByte()))
+        assertEquals("あ\r", received.toString(Charsets.UTF_8))
+        assertEquals("", capture.composeMode.buffer)
+        assertEquals(1, capture.restartRequests.size)
+    }
+
+    @Test
+    fun testSpaceAfterTrailingCommitReplayStartsFreshComposition() {
+        val capture = createComposeReplayCapture()
+
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            capture.ic.setComposingText("a", 1)
+            capture.ic.setComposingText("あ", 1)
+            capture.ic.sendKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_ENTER))
+            capture.ic.commitText("あ", 1)
+            capture.ic.setComposingText(" ", 1)
+        }
+        drainMainLooper()
+
+        assertEquals(" ", capture.composeMode.buffer)
+        assertEquals(1, capture.restartRequests.size)
     }
 
     // === Soft-keyboard TYPE_NULL key event routing ===

--- a/lib/src/test/java/org/connectbot/terminal/ImeInputViewTest.kt
+++ b/lib/src/test/java/org/connectbot/terminal/ImeInputViewTest.kt
@@ -454,6 +454,42 @@ class ImeInputViewTest {
         assertEquals(1, capture.restartRequests.size)
     }
 
+    @Test
+    fun testTrailingSetComposingReplayAfterEnterDoesNotRefillComposeBuffer() {
+        val capture = createComposeReplayCapture()
+
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            capture.ic.setComposingText("a", 1)
+            capture.ic.setComposingText("あ", 1)
+            capture.ic.sendKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_ENTER))
+            capture.ic.setComposingText("あ", 1)
+        }
+        drainMainLooper()
+
+        val received = capture.outputs.flatMap { it.toList() }.toByteArray()
+        assertTrue("Trailing setComposing replay emitted DEL and removed submitted text", !received.contains(0x7F.toByte()))
+        assertEquals("あ\r", received.toString(Charsets.UTF_8))
+        assertEquals("", capture.composeMode.buffer)
+        assertEquals(1, capture.restartRequests.size)
+    }
+
+    @Test
+    fun testSpaceAfterTrailingSetComposingReplayStartsFreshComposition() {
+        val capture = createComposeReplayCapture()
+
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            capture.ic.setComposingText("a", 1)
+            capture.ic.setComposingText("あ", 1)
+            capture.ic.sendKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_ENTER))
+            capture.ic.setComposingText("あ", 1)
+            capture.ic.setComposingText(" ", 1)
+        }
+        drainMainLooper()
+
+        assertEquals(" ", capture.composeMode.buffer)
+        assertEquals(1, capture.restartRequests.size)
+    }
+
     // === Soft-keyboard TYPE_NULL key event routing ===
 
     private fun createNonComposeModeCapture(): Triple<InputConnection, ImeInputView, MutableList<ByteArray>> {

--- a/lib/src/test/java/org/connectbot/terminal/KeyboardHandlerTest.kt
+++ b/lib/src/test/java/org/connectbot/terminal/KeyboardHandlerTest.kt
@@ -314,6 +314,30 @@ class KeyboardHandlerTest {
     }
 
     @Test
+    fun testComposeModeBackspacePassthroughRespectsDelKeyModeBackspace() {
+        // When compose buffer is empty and DelKeyMode.Backspace is active, the pass-through
+        // Backspace must send ^H (0x08), not DEL (0x7f).
+        val outputs = mutableListOf<ByteArray>()
+        val emulator = TerminalEmulatorFactory.create(
+            initialRows = 24,
+            initialCols = 80,
+            onKeyboardInput = { data -> outputs.add(data.copyOf()) },
+        )
+        val handler = KeyboardHandler(emulator)
+        handler.delKeyMode = DelKeyMode.Backspace
+        val composeMode = ComposeMode()
+        composeMode.activate()
+        handler.composeMode = composeMode
+
+        handler.onKeyEvent(createKeyEvent(Key.Backspace, KeyEventType.KeyDown))
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+
+        val received = outputs.flatMap { it.toList() }.toByteArray()
+        assertTrue("Expected ^H (0x08) in Backspace mode", received.contains(0x08.toByte()))
+        assertFalse("Should NOT send DEL (0x7f) in Backspace mode", received.contains(0x7F.toByte()))
+    }
+
+    @Test
     fun testComposeModeEscapeCancelsCompositionInProgress() {
         val composeMode = ComposeMode()
         composeMode.activate()

--- a/lib/src/test/java/org/connectbot/terminal/KeyboardHandlerTest.kt
+++ b/lib/src/test/java/org/connectbot/terminal/KeyboardHandlerTest.kt
@@ -287,25 +287,61 @@ class KeyboardHandlerTest {
         val composeMode = ComposeMode()
         composeMode.activate()
         keyboardHandler.composeMode = composeMode
+        keyboardHandler.onInputProcessed = { inputProcessedCallCount++ }
 
         keyboardHandler.onKeyEvent(createKeyEvent(Key.A, KeyEventType.KeyDown))
         keyboardHandler.onKeyEvent(createKeyEvent(Key.B, KeyEventType.KeyDown))
         keyboardHandler.onKeyEvent(createKeyEvent(Key.Backspace, KeyEventType.KeyDown))
 
         assertEquals("a", composeMode.buffer)
+        // Backspace with non-empty buffer just edits the buffer; no terminal dispatch.
+        assertEquals(0, inputProcessedCallCount)
     }
 
     @Test
-    fun testComposeModeEscapeCancels() {
+    fun testComposeModeBackspacePassesThroughWhenBufferEmpty() {
         val composeMode = ComposeMode()
         composeMode.activate()
         keyboardHandler.composeMode = composeMode
+        keyboardHandler.onInputProcessed = { inputProcessedCallCount++ }
+
+        keyboardHandler.onKeyEvent(createKeyEvent(Key.Backspace, KeyEventType.KeyDown))
+
+        assertTrue(composeMode.isActive)
+        assertEquals("", composeMode.buffer)
+        // Backspace with empty buffer is dispatched to the terminal as a real Backspace.
+        assertEquals(1, inputProcessedCallCount)
+    }
+
+    @Test
+    fun testComposeModeEscapeCancelsCompositionInProgress() {
+        val composeMode = ComposeMode()
+        composeMode.activate()
+        keyboardHandler.composeMode = composeMode
+        keyboardHandler.onInputProcessed = { inputProcessedCallCount++ }
 
         keyboardHandler.onKeyEvent(createKeyEvent(Key.A, KeyEventType.KeyDown))
         keyboardHandler.onKeyEvent(createKeyEvent(Key.Escape, KeyEventType.KeyDown))
 
-        assertFalse(composeMode.isActive)
+        assertTrue(composeMode.isActive)
         assertEquals("", composeMode.buffer)
+        // Esc with non-empty buffer just cancels the composition; no terminal dispatch.
+        assertEquals(0, inputProcessedCallCount)
+    }
+
+    @Test
+    fun testComposeModeEscapePassesThroughWhenBufferEmpty() {
+        val composeMode = ComposeMode()
+        composeMode.activate()
+        keyboardHandler.composeMode = composeMode
+        keyboardHandler.onInputProcessed = { inputProcessedCallCount++ }
+
+        keyboardHandler.onKeyEvent(createKeyEvent(Key.Escape, KeyEventType.KeyDown))
+
+        assertTrue(composeMode.isActive)
+        assertEquals("", composeMode.buffer)
+        // Esc with empty buffer is dispatched to the terminal as a real Escape key.
+        assertEquals(1, inputProcessedCallCount)
     }
 
     @Test
@@ -319,7 +355,8 @@ class KeyboardHandlerTest {
         keyboardHandler.onKeyEvent(createKeyEvent(Key.B, KeyEventType.KeyDown))
         keyboardHandler.onKeyEvent(createKeyEvent(Key.Enter, KeyEventType.KeyDown))
 
-        assertFalse(composeMode.isActive)
+        assertTrue(composeMode.isActive)
+        assertEquals("", composeMode.buffer)
         assertEquals(1, inputProcessedCallCount)
     }
 


### PR DESCRIPTION
  Keep compose mode sticky and fix IME commit/replay handling

  Body

  ## Summary

  This branch tightens terminal input handling for compose mode, IME commits, and physical keyboard modifier resolution.

  Key changes:

  - Keep compose mode active after Enter commits and Escape cancels, instead of turning compose mode off.
  - Send finalized IME commitText() input directly to the terminal rather than leaving it in the compose buffer.
  - Ignore Gboard’s post-Enter replay of the just-submitted composition so text is not duplicated and the compose overlay clears correctly.
  - Reset the IME buffer/selection state after dispatched key events to avoid stale suggestion context.
  - Resolve printable characters through the correct KeyCharacterMap for the originating device and refine right-alt/AltGr handling for physical keyboards.

  ## Why

  The current behavior had a few rough edges around Android IME input:

  - sticky compose mode was not actually sticky across common actions like Enter and Escape
  - some IMEs, especially Gboard, can replay committed composition after Enter, causing duplicate or stale composed text
  - committed IME text should become terminal input immediately instead of staying attached to the local compose overlay
  - physical keyboard character lookup could miss the correct layout/modifier behavior when device-specific key maps or AltGr were involved