### PR TITLE
ImeInputView: cap deleteSurroundingText + drop stale composition on reset

### DIFF
--- a/lib/src/main/java/org/connectbot/terminal/ImeInputView.kt
+++ b/lib/src/main/java/org/connectbot/terminal/ImeInputView.kt
@@ -129,7 +129,16 @@ internal class ImeInputView(
      * suggestion context stays in sync with the terminal's stateless text model.
      */
     fun resetImeBuffer() {
+        // Clear both the Editable AND the composing-text tracking so an
+        // in-flight IME composition doesn't resume against stale state.
+        // Without the composition reset, a mid-composition interruption
+        // from an external key path (hardware keyboard, macro key, IME
+        // dismissal) leaves the tracked composingText non-empty, and the
+        // next setComposingText() computes its backspace-count against
+        // that stale length — producing ghost backspaces or duplicated
+        // input on the next IME message.
         activeConnection?.editable?.clear()
+        activeConnection?.resetComposition()
         onUpdateSelection(this, 0, 0, -1, -1)
     }
 
@@ -203,14 +212,18 @@ internal class ImeInputView(
                 return sendKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_DEL))
             }
 
-            // Delete multiple characters (leftLength backspaces)
-            for (i in 0 until leftLength) {
+            // Cap the loop: real IMEs send single-digit values here. A misbehaving
+            // or hostile IME asking for ~2^31 deletions would freeze the UI thread
+            // in a DEL-key loop. MAX_DELETE_SURROUNDING is well above anything
+            // legitimate.
+            val bounded = leftLength.coerceIn(0, MAX_DELETE_SURROUNDING)
+            for (i in 0 until bounded) {
                 sendKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_DEL))
             }
 
             // TODO: Implement forward delete if rightLength > 0
-            if (leftLength > 0 && composingText.isNotEmpty()) {
-                val newLength = (composingText.length - leftLength).coerceAtLeast(0)
+            if (bounded > 0 && composingText.isNotEmpty()) {
+                val newLength = (composingText.length - bounded).coerceAtLeast(0)
                 composingText = composingText.substring(0, newLength)
             }
 
@@ -290,5 +303,21 @@ internal class ImeInputView(
                 keyboardHandler.onTextInput(text.toByteArray(Charsets.UTF_8))
             }
         }
+
+        /**
+         * Drop in-flight composition tracking without touching the terminal
+         * output. Called from [ImeInputView.resetImeBuffer] so an interrupted
+         * composition (e.g. external hardware-key events, IME dismissal mid-
+         * conversion) doesn't leave stale length state that a subsequent
+         * [setComposingText] would compute its backspace count against.
+         */
+        internal fun resetComposition() {
+            composingText = ""
+        }
+    }
+
+    companion object {
+        /** Upper bound on [InputConnection.deleteSurroundingText]'s `leftLength`. */
+        private const val MAX_DELETE_SURROUNDING = 4096
     }
 }

--- a/lib/src/main/java/org/connectbot/terminal/ImeInputView.kt
+++ b/lib/src/main/java/org/connectbot/terminal/ImeInputView.kt
@@ -311,7 +311,7 @@ internal class ImeInputView(
          * conversion) doesn't leave stale length state that a subsequent
          * [setComposingText] would compute its backspace count against.
          */
-        internal fun resetComposition() {
+        fun resetComposition() {
             composingText = ""
         }
     }

--- a/lib/src/test/java/org/connectbot/terminal/ImeInputViewTest.kt
+++ b/lib/src/test/java/org/connectbot/terminal/ImeInputViewTest.kt
@@ -49,6 +49,7 @@ class ImeInputViewTest {
 
     private fun makeView(
         selectionUpdates: MutableList<SelectionUpdate>? = null,
+        handler: KeyboardHandler = keyboardHandler,
     ): ImeInputView {
         val onUpdateSelection: (View, Int, Int, Int, Int) -> Unit =
             if (selectionUpdates != null) {
@@ -58,7 +59,7 @@ class ImeInputViewTest {
             } else {
                 { _, _, _, _, _ -> }
             }
-        return ImeInputView(context, keyboardHandler, noOpImm, onUpdateSelection)
+        return ImeInputView(context, handler, noOpImm, onUpdateSelection)
     }
 
     data class SelectionUpdate(
@@ -737,6 +738,10 @@ class ImeInputViewTest {
      */
     @Test
     fun testResetImeBufferDropsCompositionSoNextSetComposingStartsClean() {
+        // Uses an output-capturing KeyboardHandler so we can observe the
+        // backspace bytes dispatched by setComposingText, then runs through
+        // makeView()/view.ic(composeMode = true) so the setup matches the
+        // other resetImeBuffer tests.
         val outputs = mutableListOf<ByteArray>()
         val captureEmulator = TerminalEmulatorFactory.create(
             initialRows = 24,
@@ -744,34 +749,26 @@ class ImeInputViewTest {
             onKeyboardInput = { data -> outputs.add(data.copyOf()) },
         )
         val captureHandler = KeyboardHandler(captureEmulator)
+        val view = makeView(handler = captureHandler)
+        val ic = view.ic(composeMode = true)
 
-        lateinit var view: ImeInputView
-        lateinit var ic: InputConnection
-        InstrumentationRegistry.getInstrumentation().runOnMainSync {
-            view = ImeInputView(context, captureHandler)
-            view.isComposeModeActive = true
-            ic = view.onCreateInputConnection(EditorInfo())!!
-        }
+        // Build up a 5-char composition in the background
+        ic.setComposingText("hello", 1)
+        // External key path interrupts — buffer reset
+        view.resetImeBuffer()
+        // New composition starts from scratch. Without the reset, the internal
+        // composingText would still read "hello" and the next setComposingText
+        // would dispatch 5 backspaces before projecting "a".
+        ic.setComposingText("a", 1)
 
-        InstrumentationRegistry.getInstrumentation().runOnMainSync {
-            // Build up a 5-char composition in the background
-            ic.setComposingText("hello", 1)
-            // External key path interrupts — buffer reset
-            view.resetImeBuffer()
-            // New composition starts from scratch. Without the reset, the internal
-            // composingText would still read "hello" and the next setComposingText
-            // would dispatch 5 backspaces before projecting "a".
-            ic.setComposingText("a", 1)
+        // With the reset, no DEL (0x7F) bytes should be dispatched for the
+        // second setComposingText. Before the fix the count was 5 — one DEL
+        // per char of the stale "hello" composition. Counts 0x7F only to
+        // match the companion test (testDeleteSurroundingTextCapsAbsurdLeftLength)
+        // — KeyboardHandler's default DEL-key mapping emits 0x7F.
+        val delCount = outputs.sumOf { bytes ->
+            bytes.count { (it.toInt() and 0xFF) == 0x7F }
         }
-        drainMainLooper()
-
-        // Final state should reflect just "a", with no stray backspaces from the
-        // pre-reset composition length.
-        val del = outputs.sumOf { bytes ->
-            bytes.count { b -> (b.toInt() and 0xFF) == 0x7F || (b.toInt() and 0xFF) == 0x08 }
-        }
-        // With the reset, del count from the second setComposingText must be 0.
-        // (Before the fix, del count was 5 — one DEL per char of "hello".)
-        assertEquals("no backspaces should be dispatched after a fresh reset", 0, del)
+        assertEquals("no backspaces should be dispatched after a fresh reset", 0, delCount)
     }
 }

--- a/lib/src/test/java/org/connectbot/terminal/ImeInputViewTest.kt
+++ b/lib/src/test/java/org/connectbot/terminal/ImeInputViewTest.kt
@@ -720,9 +720,7 @@ class ImeInputViewTest {
         drainMainLooper()
 
         // Cap is 4096 — assert we got no more than that many DEL bytes.
-        val delCount = outputs.sumOf { bytes ->
-            bytes.count { (it.toInt() and 0xFF) == 0x7F }
-        }
+        val delCount = countDelBytes(outputs)
         assertTrue("delete count should be capped, got $delCount", delCount <= 4096)
     }
 
@@ -763,12 +761,19 @@ class ImeInputViewTest {
 
         // With the reset, no DEL (0x7F) bytes should be dispatched for the
         // second setComposingText. Before the fix the count was 5 — one DEL
-        // per char of the stale "hello" composition. Counts 0x7F only to
-        // match the companion test (testDeleteSurroundingTextCapsAbsurdLeftLength)
-        // — KeyboardHandler's default DEL-key mapping emits 0x7F.
-        val delCount = outputs.sumOf { bytes ->
-            bytes.count { (it.toInt() and 0xFF) == 0x7F }
-        }
-        assertEquals("no backspaces should be dispatched after a fresh reset", 0, delCount)
+        // per char of the stale "hello" composition.
+        assertEquals(
+            "no backspaces should be dispatched after a fresh reset",
+            0,
+            countDelBytes(outputs),
+        )
     }
+
+    /**
+     * KeyboardHandler's default DEL-key mapping emits 0x7F for
+     * `KEYCODE_DEL`. Both robustness tests above dispatch DEL through the
+     * identical sendKeyEvent path, so they share this helper instead of
+     * inlining the byte-counter twice.
+     */
+    private fun countDelBytes(outputs: List<ByteArray>): Int = outputs.sumOf { bytes -> bytes.count { (it.toInt() and 0xFF) == 0x7F } }
 }

--- a/lib/src/test/java/org/connectbot/terminal/ImeInputViewTest.kt
+++ b/lib/src/test/java/org/connectbot/terminal/ImeInputViewTest.kt
@@ -700,4 +700,78 @@ class ImeInputViewTest {
 
         assertEquals(" ", effectiveText(outputs))
     }
+
+    // === Robustness: deleteSurroundingText upper bound ===
+
+    /**
+     * A misbehaving or hostile IME can call [InputConnection.deleteSurroundingText]
+     * with an unbounded (Int.MAX_VALUE-ish) left length. Without a cap that would
+     * freeze the UI thread in a DEL-key dispatch loop. Cap is well above anything
+     * any real IME sends (real values are 0–few).
+     */
+    @Test
+    fun testDeleteSurroundingTextCapsAbsurdLeftLength() {
+        val (ic, outputs) = createKeyboardOutputCapture()
+
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            ic.deleteSurroundingText(Int.MAX_VALUE, 0)
+        }
+        drainMainLooper()
+
+        // Cap is 4096 — assert we got no more than that many DEL bytes.
+        val delCount = outputs.sumOf { bytes ->
+            bytes.count { (it.toInt() and 0xFF) == 0x7F }
+        }
+        assertTrue("delete count should be capped, got $delCount", delCount <= 4096)
+    }
+
+    // === Robustness: resetImeBuffer drops stale composition state ===
+
+    /**
+     * [ImeInputView.resetImeBuffer] used to clear only the Editable and the IME's
+     * selection, leaving the internal `composingText` tracking string non-empty.
+     * A composition interrupted by an external key path (hardware keyboard, macro
+     * key, IME dismissal mid-conversion) would resume against stale state on the
+     * next [setComposingText], producing ghost backspaces sized to the old
+     * composition. Reset both.
+     */
+    @Test
+    fun testResetImeBufferDropsCompositionSoNextSetComposingStartsClean() {
+        val outputs = mutableListOf<ByteArray>()
+        val captureEmulator = TerminalEmulatorFactory.create(
+            initialRows = 24,
+            initialCols = 80,
+            onKeyboardInput = { data -> outputs.add(data.copyOf()) },
+        )
+        val captureHandler = KeyboardHandler(captureEmulator)
+
+        lateinit var view: ImeInputView
+        lateinit var ic: InputConnection
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            view = ImeInputView(context, captureHandler)
+            view.isComposeModeActive = true
+            ic = view.onCreateInputConnection(EditorInfo())!!
+        }
+
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            // Build up a 5-char composition in the background
+            ic.setComposingText("hello", 1)
+            // External key path interrupts — buffer reset
+            view.resetImeBuffer()
+            // New composition starts from scratch. Without the reset, the internal
+            // composingText would still read "hello" and the next setComposingText
+            // would dispatch 5 backspaces before projecting "a".
+            ic.setComposingText("a", 1)
+        }
+        drainMainLooper()
+
+        // Final state should reflect just "a", with no stray backspaces from the
+        // pre-reset composition length.
+        val del = outputs.sumOf { bytes ->
+            bytes.count { b -> (b.toInt() and 0xFF) == 0x7F || (b.toInt() and 0xFF) == 0x08 }
+        }
+        // With the reset, del count from the second setComposingText must be 0.
+        // (Before the fix, del count was 5 — one DEL per char of "hello".)
+        assertEquals("no backspaces should be dispatched after a fresh reset", 0, del)
+    }
 }


### PR DESCRIPTION
Two small robustness fixes I came across while working downstream in Haven — both are defensive bug fixes in `ImeInputView` / `TerminalInputConnection` that apply cleanly against `main`. Opening them as one small PR because they're trivial individually but together they pin two distinct classes of IME misbehaviour.

## 1. Cap `deleteSurroundingText`'s `leftLength`

`InputConnection.deleteSurroundingText(leftLength, _)` has no documented upper bound, and some IMEs (or a hostile one) can call it with `Int.MAX_VALUE` or similar. The current loop:

```kotlin
for (i in 0 until leftLength) {
    sendKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_DEL))
}
```

…would freeze the UI thread dispatching billions of DEL key events. Real IMEs send single-digit values; the cap (`MAX_DELETE_SURROUNDING = 4096`) is well above anything legitimate and well below any noticeable UI stall.

## 2. `resetImeBuffer()` also drops `composingText`

The old `resetImeBuffer()` cleared the `BaseInputConnection` editable and called `onUpdateSelection(0, 0, -1, -1)`, but left the internal `composingText` tracking string non-empty. If a composition was interrupted mid-flow (hardware keyboard / macro-key / IME dismissal mid-conversion), the next `setComposingText()` would compute its backspace count against that stale length and dispatch backspaces sized to the *old* composition — producing ghost backspaces on a fresh composition.

The fix adds a small `resetComposition()` method on `TerminalInputConnection` and calls it from `resetImeBuffer()` alongside the existing `editable.clear()`.

## Tests

Two new cases in `ImeInputViewTest`, following the existing Robolectric pattern you just adopted:

- `testDeleteSurroundingTextCapsAbsurdLeftLength` — calls `deleteSurroundingText(Int.MAX_VALUE, 0)` and asserts no more than 4096 DEL bytes reach the keyboard capture.
- `testResetImeBufferDropsCompositionSoNextSetComposingStartsClean` — builds a 5-char composition, calls `resetImeBuffer()`, then starts a new composition with `setComposingText("a")` and asserts **zero** backspaces are dispatched between the reset and the new composition.

`./gradlew :lib:testDebugUnitTest --tests "org.connectbot.terminal.ImeInputViewTest"` → 36/36 pass locally (34 existing + 2 new).

## Context

I maintain a [Haven](https://github.com/GlassOnTin/Haven) fork of termlib that's accumulated some other changes on top — a floating overlay for CJK composition during IME conversion, a fix for the wrapped-URL detector that was reverted in #155, some extra test coverage for CJK commit-text paths (BMP kanji, supplementary-plane surrogate pairs, dakuten handling). Happy to break any of those out into follow-up PRs if they'd be useful; wanted to start with the smallest, clearest, least-opinionated slice to see if the contribution model works for you.