### PR TITLE
Terminal: clamp selection Copy/Paste buttons within viewport

### DIFF
--- a/lib/src/main/java/org/connectbot/terminal/Terminal.kt
+++ b/lib/src/main/java/org/connectbot/terminal/Terminal.kt
@@ -1184,9 +1184,17 @@ fun TerminalWithAccessibility(
         if (selectionManager.mode != SelectionMode.NONE && !selectionManager.isSelecting) {
             val range = selectionManager.selectionRange
             if (range != null) {
-                // Position copy button above the selection
+                // Position buttons above the selection. Clamp both axes so
+                // the Row stays within the terminal's viewport — selections
+                // that end near the right edge (or on row 0) used to push
+                // the Copy/Paste buttons off-screen.
                 val endPosition = range.getEndPosition()
-                val buttonX = endPosition.second * baseCharWidth
+                val rowWidthPx = with(density) {
+                    (COPY_BUTTON_SIZE * 2 + 4.dp).toPx()
+                }
+                val terminalWidthPx = screenState.snapshot.cols * baseCharWidth
+                val rawX = endPosition.second * baseCharWidth
+                val buttonX = rawX.coerceIn(0f, (terminalWidthPx - rowWidthPx).coerceAtLeast(0f))
                 val buttonY = endPosition.first * baseCharHeight - with(density) { COPY_BUTTON_OFFSET.toPx() }
 
                 Box(


### PR DESCRIPTION
Small UI fix I ran into downstream in Haven.

When text is selected, the Copy/Paste button row is anchored to the selection's end position:

```kotlin
val buttonX = endPosition.second * baseCharWidth
```

For a selection whose end column is close to the right edge of the terminal, the buttons slide off-screen on the right. Same on the top row when `endPosition.first == 0` — the Row floats above the terminal chrome.

Clamp both axes to the terminal's viewport so the buttons stay fully visible regardless of where the selection ends:

```kotlin
val rowWidthPx = with(density) { (COPY_BUTTON_SIZE * 2 + 4.dp).toPx() }
val terminalWidthPx = screenState.snapshot.cols * baseCharWidth
val rawX = endPosition.second * baseCharWidth
val buttonX = rawX.coerceIn(0f, (terminalWidthPx - rowWidthPx).coerceAtLeast(0f))
val buttonY = endPosition.first * baseCharHeight - with(density) { COPY_BUTTON_OFFSET.toPx() }
// existing .offset(y = buttonY.coerceAtLeast(0f).toDp()) handles the top-edge clamp
```

## Test plan

- Existing unit tests still pass: `./gradlew :lib:testDebugUnitTest` → 🟢
- Repro downstream: on a narrow terminal (≤ 40 cols in portrait), long-press text ending within 5-6 cols of the right edge. Before: Copy/Paste FAB row is half-clipped or fully off the right; after: clamped just inside the viewport.

## Reporter

Reported downstream by [@mio-19](https://github.com/mio-19) in [GlassOnTin/Haven#98](https://github.com/GlassOnTin/Haven/issues/98). Happy to add a screenshot test if that's a pattern you'd want here.