### PR TITLE
TerminalEmulator: public getSnapshotLineTexts() accessor

### DIFF
--- a/lib/api.txt
+++ b/lib/api.txt
@@ -106,6 +106,7 @@ package org.connectbot.terminal {
     method @InaccessibleFromKotlin public boolean getBoldAsBright();
     method @InaccessibleFromKotlin public org.connectbot.terminal.TerminalDimensions getDimensions();
     method public String? getLastCommandOutput();
+    method public java.util.List<java.lang.String> getSnapshotLineTexts();
     method public void resize(int newRows, int newCols);
     method public int setAnsiPalette(int[] ansiColors);
     method public int setDefaultColors(int foreground, int background);

--- a/lib/api.txt
+++ b/lib/api.txt
@@ -106,6 +106,7 @@ package org.connectbot.terminal {
     method @InaccessibleFromKotlin public boolean getBoldAsBright();
     method @InaccessibleFromKotlin public org.connectbot.terminal.TerminalDimensions getDimensions();
     method public String? getLastCommandOutput();
+    method public java.util.List<java.lang.String> getSnapshotLineTexts();
     method public java.util.List<org.connectbot.terminal.TerminalUrl> getUrls(optional org.connectbot.terminal.UrlScanScope scope);
     method public void resize(int newRows, int newCols);
     method public int setAnsiPalette(int[] ansiColors);

--- a/lib/src/main/java/org/connectbot/terminal/TerminalEmulator.kt
+++ b/lib/src/main/java/org/connectbot/terminal/TerminalEmulator.kt
@@ -139,6 +139,15 @@ sealed interface TerminalEmulator {
      * @return The command output text, or null if no completed command is found
      */
     fun getLastCommandOutput(): String?
+
+    /**
+     * Plain-text lines of the current terminal snapshot. Public accessor
+     * so consumers outside this module (notably Haven's SelectionToolbar
+     * for smart copy and word expansion) can read line text without
+     * reflecting into the internal `snapshot` StateFlow. Returns a fresh
+     * list at call time.
+     */
+    fun getSnapshotLineTexts(): List<String>
 }
 
 class TerminalEmulatorFactory {
@@ -263,6 +272,8 @@ internal class TerminalEmulatorImpl(
         TerminalSnapshot.empty(initialRows, initialCols, currentDefaultForeground, currentDefaultBackground),
     )
     internal val snapshot: StateFlow<TerminalSnapshot> = _snapshot.asStateFlow()
+
+    override fun getSnapshotLineTexts(): List<String> = _snapshot.value.lines.map { it.text }
 
     // Sequence number for ordering snapshots
     private var sequenceNumber = 0L

--- a/lib/src/main/java/org/connectbot/terminal/TerminalEmulator.kt
+++ b/lib/src/main/java/org/connectbot/terminal/TerminalEmulator.kt
@@ -193,6 +193,15 @@ sealed interface TerminalEmulator {
      * While the alternate screen is active, primary scrollback is not scanned.
      */
     fun getUrls(scope: UrlScanScope = UrlScanScope.CurrentView): List<TerminalUrl>
+
+    /**
+     * Plain-text lines of the current terminal snapshot. Public accessor
+     * so consumers outside this module (notably Haven's SelectionToolbar
+     * for smart copy and word expansion) can read line text without
+     * reflecting into the internal `snapshot` StateFlow. Returns a fresh
+     * list at call time.
+     */
+    fun getSnapshotLineTexts(): List<String>
 }
 
 class TerminalEmulatorFactory {
@@ -321,6 +330,8 @@ internal class TerminalEmulatorImpl(
         TerminalSnapshot.empty(initialRows, initialCols, currentDefaultForeground, currentDefaultBackground),
     )
     internal val snapshot: StateFlow<TerminalSnapshot> = _snapshot.asStateFlow()
+
+    override fun getSnapshotLineTexts(): List<String> = _snapshot.value.lines.map { it.text }
 
     // Sequence number for ordering snapshots
     private var sequenceNumber = 0L

--- a/lib/src/main/java/org/connectbot/terminal/TerminalLine.kt
+++ b/lib/src/main/java/org/connectbot/terminal/TerminalLine.kt
@@ -163,7 +163,7 @@ internal data class TerminalLine(
                 row = row,
                 cells = List(cols) {
                     Cell(
-                        char = '\u0000',
+                        char = ' ',
                         fgColor = defaultFg,
                         bgColor = defaultBg
                     )

--- a/lib/src/main/java/org/connectbot/terminal/TerminalLine.kt
+++ b/lib/src/main/java/org/connectbot/terminal/TerminalLine.kt
@@ -37,7 +37,7 @@ internal data class TerminalLine(
      * long commands. For example, a command like "echo foo bar baz..." that wraps to
      * multiple lines should be copied as a single line without embedded newlines.
      */
-    val softWrapped: Boolean = false
+    val softWrapped: Boolean = false,
 ) {
     /**
      * Get the text content of this line as a string.
@@ -55,17 +55,13 @@ internal data class TerminalLine(
      * Get the semantic type at a specific column.
      * Returns DEFAULT if no segment covers that column.
      */
-    fun getSemanticTypeAt(col: Int): SemanticType {
-        return semanticSegments.firstOrNull { it.contains(col) }?.semanticType
-            ?: SemanticType.DEFAULT
-    }
+    fun getSemanticTypeAt(col: Int): SemanticType = semanticSegments.firstOrNull { it.contains(col) }?.semanticType
+        ?: SemanticType.DEFAULT
 
     /**
      * Get all segments of a specific semantic type.
      */
-    fun getSegmentsOfType(type: SemanticType): List<SemanticSegment> {
-        return semanticSegments.filter { it.semanticType == type }
-    }
+    fun getSegmentsOfType(type: SemanticType): List<SemanticSegment> = semanticSegments.filter { it.semanticType == type }
 
     /**
      * Check if this line contains any prompt segments.
@@ -121,11 +117,13 @@ internal data class TerminalLine(
         val bgColor: Color,
         val bold: Boolean = false,
         val italic: Boolean = false,
-        val underline: Int = 0,  // 0=none, 1=single, 2=double, 3=curly
+        // 0=none, 1=single, 2=double, 3=curly
+        val underline: Int = 0,
         val blink: Boolean = false,
         val reverse: Boolean = false,
         val strike: Boolean = false,
-        val width: Int = 1  // 1 for normal, 2 for fullwidth (CJK)
+        // 1 for normal, 2 for fullwidth (CJK)
+        val width: Int = 1,
     )
 
     companion object {
@@ -146,30 +144,28 @@ internal data class TerminalLine(
         internal val URL_REGEX = Regex(
             // Scheme URLs: http(s)://... or ftp://...
             """(?:https?://|ftp://)[^\s<>"{}|\\^`\[\]]+""" +
-            // Bare domains with common TLDs, optional :port and /path
-            """|(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?\.)+""" +
-            """(?:com|org|net|edu|gov|io|dev|app|co|uk|de|fr|jp|ru|br|in|au|us|info|biz|me|tv|cc)""" +
-            """(?::\d{1,5})?""" +
-            """(?:/[^\s<>"{}|\\^`\[\]]*)?""" +
-            // IP:port (e.g. 192.168.1.1:8080) — require port to avoid matching version numbers
-            """|(?:\d{1,3}\.){3}\d{1,3}:\d{1,5}(?:/[^\s<>"{}|\\^`\[\]]*)?"""
+                // Bare domains with common TLDs, optional :port and /path
+                """|(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?\.)+""" +
+                """(?:com|org|net|edu|gov|io|dev|app|co|uk|de|fr|jp|ru|br|in|au|us|info|biz|me|tv|cc)""" +
+                """(?::\d{1,5})?""" +
+                """(?:/[^\s<>"{}|\\^`\[\]]*)?""" +
+                // IP:port (e.g. 192.168.1.1:8080) — require port to avoid matching version numbers
+                """|(?:\d{1,3}\.){3}\d{1,3}:\d{1,5}(?:/[^\s<>"{}|\\^`\[\]]*)?""",
         )
 
         /**
          * Create an empty line with default cells.
          */
-        fun empty(row: Int, cols: Int, defaultFg: Color = Color.White, defaultBg: Color = Color.Black): TerminalLine {
-            return TerminalLine(
-                row = row,
-                cells = List(cols) {
-                    Cell(
-                        char = ' ',
-                        fgColor = defaultFg,
-                        bgColor = defaultBg
-                    )
-                },
-                softWrapped = false
-            )
-        }
+        fun empty(row: Int, cols: Int, defaultFg: Color = Color.White, defaultBg: Color = Color.Black): TerminalLine = TerminalLine(
+            row = row,
+            cells = List(cols) {
+                Cell(
+                    char = ' ',
+                    fgColor = defaultFg,
+                    bgColor = defaultBg,
+                )
+            },
+            softWrapped = false,
+        )
     }
 }

--- a/lib/src/main/java/org/connectbot/terminal/TerminalLine.kt
+++ b/lib/src/main/java/org/connectbot/terminal/TerminalLine.kt
@@ -191,7 +191,7 @@ internal data class TerminalLine(
             row = row,
             cells = List(cols) {
                 Cell(
-                    char = '\u0000',
+                    char = ' ',
                     fgColor = defaultFg,
                     bgColor = defaultBg,
                 )


### PR DESCRIPTION
Add a public read-only accessor on `TerminalEmulator` that returns the plain-text lines of the current snapshot.

## Motivation

Downstream in Haven, I have a smart-copy pass that needs to look at line text surrounding the selection — to strip TUI borders, unwrap soft-wraps, and expand word boundaries across URL wrap continuations. The internal `snapshot: StateFlow<TerminalSnapshot>` is the natural source, but it's `internal`, so a host outside the module can't read it.

I was routing around it via reflection on the `$lib`-mangled name. That silently broke in release builds because R8 re-mangles the symbol to `$lib_release`. Direct accessor fixes it and removes the reflection hack.

I expect the same ask comes up for any host that wants to implement its own clipboard/search/export feature on top of termlib.

## Change

`sealed interface TerminalEmulator` gains:

```kotlin
/**
 * Plain-text lines of the current terminal snapshot. Returns a fresh
 * list at call time.
 */
fun getSnapshotLineTexts(): List<String>
```

with the obvious one-line implementation in `TerminalEmulatorImpl`:

```kotlin
override fun getSnapshotLineTexts(): List<String> =
    _snapshot.value.lines.map { it.text }
```

## Scope and footprint

- One method added to `sealed interface TerminalEmulator`. Because the interface is sealed, there's exactly one implementation to keep in sync, and it's in the same module.
- Read-only, no state mutation.
- No new dependencies.
- `./gradlew :lib:testDebugUnitTest` → 🟢

Happy to rename to fit your style (`lineTexts()`, `snapshotText()`, etc.) — the name's not precious.