### PR TITLE
Allow delkey to be backspace

### DIFF
--- a/lib/api.txt
+++ b/lib/api.txt
@@ -12,6 +12,17 @@ package org.connectbot.terminal {
     property public default int pendingDeadChar;
   }
 
+  public abstract sealed exhaustive class DelKeyMode {
+  }
+
+  public static final class DelKeyMode.Backspace extends org.connectbot.terminal.DelKeyMode {
+    field public static final org.connectbot.terminal.DelKeyMode.Backspace INSTANCE;
+  }
+
+  public static final class DelKeyMode.Delete extends org.connectbot.terminal.DelKeyMode {
+    field public static final org.connectbot.terminal.DelKeyMode.Delete INSTANCE;
+  }
+
   public interface ModifierManager {
     method public void clearTransients();
     method public boolean isAltActive();
@@ -115,7 +126,7 @@ package org.connectbot.terminal {
   }
 
   public final class TerminalKt {
-    method @KotlinOnly @androidx.compose.runtime.Composable public static void Terminal(org.connectbot.terminal.TerminalEmulator terminalEmulator, optional androidx.compose.ui.Modifier modifier, optional android.graphics.Typeface typeface, optional androidx.compose.ui.unit.TextUnit initialFontSize, optional androidx.compose.ui.unit.TextUnit minFontSize, optional androidx.compose.ui.unit.TextUnit maxFontSize, optional androidx.compose.ui.graphics.Color backgroundColor, optional androidx.compose.ui.graphics.Color foregroundColor, optional androidx.compose.ui.graphics.Color selectionBackgroundColor, optional androidx.compose.ui.graphics.Color selectionForegroundColor, optional boolean keyboardEnabled, optional boolean showSoftKeyboard, optional androidx.compose.ui.focus.FocusRequester focusRequester, optional kotlin.jvm.functions.Function0<kotlin.Unit> onTerminalTap, optional kotlin.jvm.functions.Function1<java.lang.Boolean,kotlin.Unit> onImeVisibilityChanged, optional kotlin.Pair<java.lang.Integer,java.lang.Integer>? forcedSize, optional org.connectbot.terminal.ModifierManager? modifierManager, optional kotlin.jvm.functions.Function1<org.connectbot.terminal.SelectionController,kotlin.Unit>? onSelectionControllerAvailable, optional kotlin.jvm.functions.Function1<java.lang.String,kotlin.Unit> onHyperlinkClick, optional kotlin.jvm.functions.Function1<org.connectbot.terminal.ComposeController,kotlin.Unit>? onComposeControllerAvailable, optional kotlin.jvm.functions.Function0<kotlin.Unit>? onPasteRequest, optional org.connectbot.terminal.RightAltMode rightAltMode);
+    method @KotlinOnly @androidx.compose.runtime.Composable public static void Terminal(org.connectbot.terminal.TerminalEmulator terminalEmulator, optional androidx.compose.ui.Modifier modifier, optional android.graphics.Typeface typeface, optional androidx.compose.ui.unit.TextUnit initialFontSize, optional androidx.compose.ui.unit.TextUnit minFontSize, optional androidx.compose.ui.unit.TextUnit maxFontSize, optional androidx.compose.ui.graphics.Color backgroundColor, optional androidx.compose.ui.graphics.Color foregroundColor, optional androidx.compose.ui.graphics.Color selectionBackgroundColor, optional androidx.compose.ui.graphics.Color selectionForegroundColor, optional boolean keyboardEnabled, optional boolean showSoftKeyboard, optional androidx.compose.ui.focus.FocusRequester focusRequester, optional kotlin.jvm.functions.Function0<kotlin.Unit> onTerminalTap, optional kotlin.jvm.functions.Function1<java.lang.Boolean,kotlin.Unit> onImeVisibilityChanged, optional kotlin.Pair<java.lang.Integer,java.lang.Integer>? forcedSize, optional org.connectbot.terminal.ModifierManager? modifierManager, optional kotlin.jvm.functions.Function1<org.connectbot.terminal.SelectionController,kotlin.Unit>? onSelectionControllerAvailable, optional kotlin.jvm.functions.Function1<java.lang.String,kotlin.Unit> onHyperlinkClick, optional kotlin.jvm.functions.Function1<org.connectbot.terminal.ComposeController,kotlin.Unit>? onComposeControllerAvailable, optional kotlin.jvm.functions.Function0<kotlin.Unit>? onPasteRequest, optional org.connectbot.terminal.RightAltMode rightAltMode, optional org.connectbot.terminal.DelKeyMode delKeyMode);
   }
 
   public final class VTermKey {

--- a/lib/src/main/java/org/connectbot/terminal/DelKeyMode.kt
+++ b/lib/src/main/java/org/connectbot/terminal/DelKeyMode.kt
@@ -1,0 +1,34 @@
+/*
+ * ConnectBot Terminal
+ * Copyright 2026 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.connectbot.terminal
+
+/**
+ * Controls what byte sequence the backspace key sends.
+ */
+sealed class DelKeyMode {
+    /**
+     * Backspace key sends DEL (0x7f). This is the default.
+     * The Delete key sends ESC[3~.
+     */
+    data object Delete : DelKeyMode()
+
+    /**
+     * Backspace key sends ^H (0x08). Use for servers that expect the traditional backspace byte.
+     * The Delete key sends DEL (0x7f) instead.
+     */
+    data object Backspace : DelKeyMode()
+}

--- a/lib/src/main/java/org/connectbot/terminal/KeyboardHandler.kt
+++ b/lib/src/main/java/org/connectbot/terminal/KeyboardHandler.kt
@@ -62,6 +62,12 @@ internal class KeyboardHandler(
      */
     var rightAltMode: RightAltMode = RightAltMode.CharacterModifier,
     /**
+     * Controls whether the backspace key sends DEL (0x7f) or ^H (0x08). Defaults to
+     * [DelKeyMode.Delete]. Set to [DelKeyMode.Backspace] for servers that expect ^H.
+     * When [DelKeyMode.Backspace] is active, the Delete key sends DEL (0x7f) instead.
+     */
+    var delKeyMode: DelKeyMode = DelKeyMode.Delete,
+    /**
      * Resolves a (deviceId, keyCode, metaState) triple to a raw Unicode value as returned by
      * [android.view.KeyEvent.getUnicodeChar]. Injectable for testing dead-key logic without
      * requiring a physical keyboard with dead keys.
@@ -191,6 +197,32 @@ internal class KeyboardHandler(
             (!rightAltPressed && nativeEvent.metaState and AndroidKeyEvent.META_ALT_ON != 0)
         val alt = leftAltPressed || rightAltIsMeta
         val stripAltGr = rightAltIsMeta
+
+        // When DelKeyMode.Backspace is active, swap the byte sequences:
+        // Backspace → ^H (0x08), Delete → DEL (0x7f).
+        if (delKeyMode is DelKeyMode.Backspace) {
+            when (key) {
+                Key.Backspace -> {
+                    val modifiers = buildModifierMask(ctrl, alt, shift)
+                    pendingDeadChar = 0
+                    terminalEmulator.dispatchCharacter(modifiers, 0x08)
+                    modifierManager?.clearTransients()
+                    onInputProcessed?.invoke()
+                    return true
+                }
+
+                Key.Delete -> {
+                    val modifiers = buildModifierMask(ctrl, alt, shift)
+                    pendingDeadChar = 0
+                    terminalEmulator.dispatchKey(modifiers, VTermKey.BACKSPACE)
+                    modifierManager?.clearTransients()
+                    onInputProcessed?.invoke()
+                    return true
+                }
+
+                else -> {}
+            }
+        }
 
         // Check if this is a special key that libvterm handles
         val vtermKey = mapToVTermKey(key)

--- a/lib/src/main/java/org/connectbot/terminal/KeyboardHandler.kt
+++ b/lib/src/main/java/org/connectbot/terminal/KeyboardHandler.kt
@@ -375,29 +375,31 @@ internal class KeyboardHandler(
             return null
         }
 
+        val dead = pendingDeadChar
+        val base: Int
         if (raw and KeyCharacterMap.COMBINING_ACCENT != 0) {
-            val accent = raw and KeyCharacterMap.COMBINING_ACCENT_MASK
-            if (pendingDeadChar == accent) {
-                // Same dead key twice: emit the spacing (non-combining) version of the accent.
-                pendingDeadChar = 0
-                return accent.toLong()
+            base = raw and KeyCharacterMap.COMBINING_ACCENT_MASK
+            if (dead == 0) {
+                pendingDeadChar = base
+                return 0L
             }
-            pendingDeadChar = accent
-            return 0L
+            // No need to handle the double-combining accent here; KCM.getDeadChar does it.
+        } else {
+            base = raw
         }
 
-        val dead = pendingDeadChar
         pendingDeadChar = 0
+
         if (dead != 0) {
-            val composed = KeyCharacterMap.getDeadChar(dead, raw)
+            val composed = KeyCharacterMap.getDeadChar(dead, base)
             if (composed != 0) return composed.toLong()
 
             // Combination not possible: the caller will emit `dead` first, then we return `raw`.
             // Use bit 63 as a flag for multiple codepoints.
-            return (1L shl 63) or (dead.toLong() shl 32) or raw.toLong()
+            return (1L shl 63) or (dead.toLong() shl 32) or base.toLong()
         }
 
-        return raw.toLong()
+        return base.toLong()
     }
 
     /**

--- a/lib/src/main/java/org/connectbot/terminal/Terminal.kt
+++ b/lib/src/main/java/org/connectbot/terminal/Terminal.kt
@@ -312,6 +312,7 @@ fun Terminal(
     onComposeControllerAvailable: ((ComposeController) -> Unit)? = null,
     onPasteRequest: (() -> Unit)? = null,
     rightAltMode: RightAltMode = RightAltMode.CharacterModifier,
+    delKeyMode: DelKeyMode = DelKeyMode.Delete,
 ) {
     if (LocalInspectionMode.current) {
         TerminalPreview(modifier, backgroundColor, foregroundColor)
@@ -342,6 +343,7 @@ fun Terminal(
         rightAltMode = rightAltMode,
         selectionBackgroundColor = selectionBackgroundColor,
         selectionForegroundColor = selectionForegroundColor,
+        delKeyMode = delKeyMode,
     )
 }
 
@@ -377,6 +379,7 @@ internal fun TerminalWithAccessibility(
     rightAltMode: RightAltMode = RightAltMode.CharacterModifier,
     selectionBackgroundColor: Color = Color(0xFFB3D7FF),
     selectionForegroundColor: Color = Color.Black,
+    delKeyMode: DelKeyMode = DelKeyMode.Delete,
 ) {
     if (terminalEmulator !is TerminalEmulatorImpl) {
         Box(
@@ -410,6 +413,7 @@ internal fun TerminalWithAccessibility(
         KeyboardHandler(terminalEmulator, modifierManager)
     }
     keyboardHandler.rightAltMode = rightAltMode
+    keyboardHandler.delKeyMode = delKeyMode
 
     // Font size and zoom state
     var zoomScale by remember(terminalEmulator) { mutableStateOf(1f) }

--- a/lib/src/test/java/org/connectbot/terminal/ImeInputViewTest.kt
+++ b/lib/src/test/java/org/connectbot/terminal/ImeInputViewTest.kt
@@ -26,6 +26,7 @@ import android.view.inputmethod.InputMethodManager
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -535,6 +536,58 @@ class ImeInputViewTest {
 
         val received = outputs.flatMap { it.toList() }.toByteArray()
         assertTrue("DEL via deleteSurroundingText did not reach the terminal", received.contains(0x7F.toByte()))
+    }
+
+    // === DelKeyMode IME tests ===
+
+    private fun createNonComposeModeWithMode(delKeyMode: DelKeyMode): Pair<InputConnection, MutableList<ByteArray>> {
+        val outputs = mutableListOf<ByteArray>()
+        val emulator = TerminalEmulatorFactory.create(
+            initialRows = 24,
+            initialCols = 80,
+            onKeyboardInput = { data -> outputs.add(data.copyOf()) },
+        )
+        val handler = KeyboardHandler(emulator)
+        handler.delKeyMode = delKeyMode
+        var ic: InputConnection? = null
+
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            ImeInputView(context, handler).also { v ->
+                v.setOnKeyListener { _, _, event ->
+                    if (event.action == KeyEvent.ACTION_DOWN) v.resetImeBuffer()
+                    handler.onKeyEvent(androidx.compose.ui.input.key.KeyEvent(event))
+                }
+                ic = v.onCreateInputConnection(EditorInfo())
+            }
+        }
+        return ic!! to outputs
+    }
+
+    @Test
+    fun testImeSoftBackspaceDeleteModeDefaultDeliversDel() {
+        val (ic, outputs) = createNonComposeModeWithMode(DelKeyMode.Delete)
+
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            ic.deleteSurroundingText(1, 0)
+        }
+        drainMainLooper()
+
+        val received = outputs.flatMap { it.toList() }.toByteArray()
+        assertTrue("Expected DEL (0x7f) in default Delete mode", received.contains(0x7F.toByte()))
+    }
+
+    @Test
+    fun testImeSoftBackspaceBackspaceModeDeliversCtrlH() {
+        val (ic, outputs) = createNonComposeModeWithMode(DelKeyMode.Backspace)
+
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            ic.deleteSurroundingText(1, 0)
+        }
+        drainMainLooper()
+
+        val received = outputs.flatMap { it.toList() }.toByteArray()
+        assertTrue("Expected ^H (0x08) in Backspace mode", received.contains(0x08.toByte()))
+        assertFalse("Should NOT send DEL (0x7f) in Backspace mode", received.contains(0x7F.toByte()))
     }
 
     /**

--- a/lib/src/test/java/org/connectbot/terminal/KeyboardHandlerTest.kt
+++ b/lib/src/test/java/org/connectbot/terminal/KeyboardHandlerTest.kt
@@ -175,6 +175,73 @@ class KeyboardHandlerTest {
         assertEquals(3, inputProcessedCallCount)
     }
 
+    // === DelKeyMode tests ===
+
+    @Test
+    fun testDeleteModeDefaultBackspaceSendsDel() {
+        // Default mode (DelKeyMode.Delete): Key.Backspace → DEL (0x7f)
+        val outputs = mutableListOf<ByteArray>()
+        val emulator = TerminalEmulatorFactory.create(
+            initialRows = 24,
+            initialCols = 80,
+            onKeyboardInput = { data -> outputs.add(data.copyOf()) },
+        )
+        val handler = KeyboardHandler(emulator)
+
+        handler.onKeyEvent(createKeyEvent(Key.Backspace, KeyEventType.KeyDown))
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+
+        val received = outputs.flatMap { it.toList() }.toByteArray()
+        assertTrue("Expected DEL (0x7f) in default Delete mode", received.contains(0x7F.toByte()))
+    }
+
+    @Test
+    fun testBackspaceModeBackspaceSendsCtrlH() {
+        // DelKeyMode.Backspace: Key.Backspace → ^H (0x08)
+        val outputs = mutableListOf<ByteArray>()
+        val emulator = TerminalEmulatorFactory.create(
+            initialRows = 24,
+            initialCols = 80,
+            onKeyboardInput = { data -> outputs.add(data.copyOf()) },
+        )
+        val handler = KeyboardHandler(emulator)
+        handler.delKeyMode = DelKeyMode.Backspace
+
+        handler.onKeyEvent(createKeyEvent(Key.Backspace, KeyEventType.KeyDown))
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+
+        val received = outputs.flatMap { it.toList() }.toByteArray()
+        assertTrue("Expected ^H (0x08) in Backspace mode", received.contains(0x08.toByte()))
+        assertFalse("Should NOT send DEL (0x7f) in Backspace mode", received.contains(0x7F.toByte()))
+    }
+
+    @Test
+    fun testBackspaceModeDeleteKeySendsDel() {
+        // DelKeyMode.Backspace: Key.Delete → DEL (0x7f)
+        val outputs = mutableListOf<ByteArray>()
+        val emulator = TerminalEmulatorFactory.create(
+            initialRows = 24,
+            initialCols = 80,
+            onKeyboardInput = { data -> outputs.add(data.copyOf()) },
+        )
+        val handler = KeyboardHandler(emulator)
+        handler.delKeyMode = DelKeyMode.Backspace
+
+        val deleteKeyEvent = KeyEvent(
+            NativeKeyEvent(
+                AndroidKeyEvent(
+                    AndroidKeyEvent.ACTION_DOWN,
+                    AndroidKeyEvent.KEYCODE_FORWARD_DEL,
+                ),
+            ),
+        )
+        handler.onKeyEvent(deleteKeyEvent)
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+
+        val received = outputs.flatMap { it.toList() }.toByteArray()
+        assertTrue("Expected DEL (0x7f) for Delete key in Backspace mode", received.contains(0x7F.toByte()))
+    }
+
     private fun createKeyEvent(key: Key, type: KeyEventType): KeyEvent = KeyEvent(
         NativeKeyEvent(
             AndroidKeyEvent(


### PR DESCRIPTION
Trying to bring back all the features ConnectBot had with the old emulator. One of them was the ability to choose what "Delete" sent to the other side.