### PR TITLE
Handle legacy ACTION_MULTIPLE IME text input

### DIFF
--- a/lib/src/main/java/org/connectbot/terminal/KeyboardHandler.kt
+++ b/lib/src/main/java/org/connectbot/terminal/KeyboardHandler.kt
@@ -101,7 +101,19 @@ internal class KeyboardHandler(
      * Process a Compose KeyEvent and send to terminal.
      * Returns true if the event was handled.
      */
+    @Suppress("DEPRECATION")
     fun onKeyEvent(event: ComposeKeyEvent): Boolean {
+        val nativeEvent = event.nativeKeyEvent
+        if (nativeEvent.action == AndroidKeyEvent.ACTION_MULTIPLE &&
+            nativeEvent.keyCode == AndroidKeyEvent.KEYCODE_UNKNOWN
+        ) {
+            val characters = nativeEvent.characters
+            if (!characters.isNullOrEmpty()) {
+                onTextInput(characters.toByteArray(Charsets.UTF_8))
+                return true
+            }
+        }
+
         if (event.type != KeyEventType.KeyDown) {
             return false
         }
@@ -190,7 +202,6 @@ internal class KeyboardHandler(
         }
 
         // Determine whether right-alt counts as a terminal modifier or a character selector.
-        val nativeEvent = event.nativeKeyEvent
         val rightAltPressed = nativeEvent.hasModifiers(AndroidKeyEvent.META_ALT_RIGHT_ON)
         val rightAltIsMeta = rightAltPressed && rightAltMode == RightAltMode.Meta
         val leftAltPressed = nativeEvent.hasModifiers(AndroidKeyEvent.META_ALT_LEFT_ON) ||

--- a/lib/src/test/java/org/connectbot/terminal/ImeInputViewTest.kt
+++ b/lib/src/test/java/org/connectbot/terminal/ImeInputViewTest.kt
@@ -17,6 +17,8 @@
 package org.connectbot.terminal
 
 import android.content.Context
+import android.os.SystemClock
+import android.view.KeyCharacterMap
 import android.view.KeyEvent
 import android.view.View
 import android.view.inputmethod.BaseInputConnection
@@ -605,6 +607,34 @@ class ImeInputViewTest {
 
         val received = outputs.flatMap { it.toList() }.toByteArray()
         assertTrue("ENTER via sendKeyEvent did not reach the terminal", received.contains(0x0D.toByte()))
+    }
+
+    /**
+     * Some IMEs deliver enter-like input as ACTION_MULTIPLE + KEYCODE_UNKNOWN carrying a raw
+     * newline string instead of KEYCODE_ENTER. Old ConnectBot accepted this path; ensure the
+     * terminal still receives it.
+     */
+    @Test
+    fun testTypeNullActionMultipleUnknownNewlineReachesTerminal() {
+        val (_, view, outputs) = createNonComposeModeCapture()
+
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            view.dispatchKeyEvent(
+                KeyEvent(
+                    SystemClock.uptimeMillis(),
+                    "\n",
+                    KeyCharacterMap.VIRTUAL_KEYBOARD,
+                    0,
+                ),
+            )
+        }
+        drainMainLooper()
+
+        val received = outputs.flatMap { it.toList() }.toByteArray()
+        assertTrue(
+            "ACTION_MULTIPLE newline did not reach the terminal",
+            received.contains('\n'.code.toByte()),
+        )
     }
 
     // === Ctrl/Alt modifier key routing from soft keyboards (issue-2050) ===


### PR DESCRIPTION
Possibly fixes connectbot/connectbot#2119.

## Summary

Legacy ConnectBot `v1.9.13` handled `ACTION_MULTIPLE` / `KEYCODE_UNKNOWN`
IME text input in `TerminalKeyListener`, but the current termlib path drops
that event because `KeyboardHandler.onKeyEvent()` returns early for anything
that is not `KeyDown`.

This branch restores that legacy IME text path by:
- adding a regression test for an `ACTION_MULTIPLE` newline delivered to the terminal input view
- handling `ACTION_MULTIPLE` + `KEYCODE_UNKNOWN` before the normal `KeyDown` gate
- routing the raw characters through the existing `onTextInput()` path

## Why

Some IMEs may deliver enter-like input as `ACTION_MULTIPLE` with
`KEYCODE_UNKNOWN` and a raw newline string instead of `KEYCODE_ENTER`.

This change does not prove that `connectbot/connectbot#2119` is caused by this
exact IME path, but it restores a previously supported input path and covers
one plausible way Enter-like input can fail to reach the terminal.

## Testing

Added:
- `ImeInputViewTest.testTypeNullActionMultipleUnknownNewlineReachesTerminal`

Verified with:
- `./gradlew :lib:testDebugUnitTest --tests org.connectbot.terminal.ImeInputViewTest --tests org.connectbot.terminal.KeyboardHandlerTest`