### PR TITLE
feat: clear scrollback when requested

### DIFF
--- a/lib/src/main/cpp/Terminal.cpp
+++ b/lib/src/main/cpp/Terminal.cpp
@@ -92,6 +92,10 @@ Terminal::Terminal(JNIEnv* env, jobject callbacks, int rows, int cols)
     if (!mPopScrollbackMethod) {
         LOGE("Failed to find popScrollbackLine method");
     }
+    mClearScrollbackMethod = env->GetMethodID(callbacksClass, "clearScrollback", "()I");
+    if (!mClearScrollbackMethod) {
+        LOGE("Failed to find clearScrollback method");
+    }
     mKeyboardInputMethod = env->GetMethodID(callbacksClass, "onKeyboardInput", "([B)I");
     if (!mKeyboardInputMethod) {
         LOGE("Failed to find onKeyboardInput method");
@@ -198,7 +202,7 @@ Terminal::Terminal(JNIEnv* env, jobject callbacks, int rows, int cols)
         .resize = nullptr,  // We handle resize explicitly
         .sb_pushline = termSbPushline,
         .sb_popline = termSbPopline,
-        .sb_clear = nullptr  // Not needed
+        .sb_clear = termSbClear
     };
     vterm_screen_set_callbacks(mVts, &mScreenCallbacks, this);
 
@@ -573,6 +577,12 @@ int Terminal::termSbPushline(int cols, const VTermScreenCell* cells, void* user)
 int Terminal::termSbPopline(int cols, VTermScreenCell* cells, void* user) {
     auto* term = static_cast<Terminal*>(user);
     return term->invokePopScrollbackLine(cols, cells);
+}
+
+int Terminal::termSbClear(void* user) {
+    auto* term = static_cast<Terminal*>(user);
+    term->invokeClearScrollback();
+    return 1;
 }
 
 void Terminal::termOutput(const char* s, size_t len, void* user) {
@@ -1017,6 +1027,20 @@ int Terminal::invokePopScrollbackLine(int cols, VTermScreenCell* cells) {
     }
 
     return 1;
+}
+
+void Terminal::invokeClearScrollback() {
+    if (!mClearScrollbackMethod) {
+        return;
+    }
+
+    JNIEnv* env;
+    if (mJavaVM->GetEnv((void**)&env, JNI_VERSION_1_6) != JNI_OK) {
+        return;
+    }
+
+    env->CallIntMethod(mCallbacks, mClearScrollbackMethod);
+    JNI_CHECK_EXCEPTION(env);
 }
 
 void Terminal::invokeKeyboardOutput(const char* data, size_t len) {

--- a/lib/src/main/cpp/Terminal.h
+++ b/lib/src/main/cpp/Terminal.h
@@ -83,6 +83,7 @@ private:
     static int termBell(void* user);
     static int termSbPushline(int cols, const VTermScreenCell* cells, void* user);
     static int termSbPopline(int cols, VTermScreenCell* cells, void* user);
+    static int termSbClear(void* user);
 
     // libvterm output callback (keyboard generates this)
     static void termOutput(const char* s, size_t len, void* user);
@@ -102,6 +103,7 @@ private:
     void invokeBell();
     void invokePushScrollbackLine(int cols, const VTermScreenCell* cells, bool softWrapped);
     int invokePopScrollbackLine(int cols, VTermScreenCell* cells);
+    void invokeClearScrollback();
     void invokeKeyboardOutput(const char* data, size_t len);
     int invokeOscSequence(int command, const std::string& payload, int cursorRow, int cursorCol);
 
@@ -140,6 +142,7 @@ private:
     jmethodID mBellMethod;
     jmethodID mPushScrollbackMethod;
     jmethodID mPopScrollbackMethod;
+    jmethodID mClearScrollbackMethod;
     jmethodID mKeyboardInputMethod;
     jmethodID mOscSequenceMethod;
 

--- a/lib/src/main/java/org/connectbot/terminal/TerminalCallbacks.kt
+++ b/lib/src/main/java/org/connectbot/terminal/TerminalCallbacks.kt
@@ -94,6 +94,13 @@ internal interface TerminalCallbacks {
     fun popScrollbackLine(cols: Int, cells: Array<ScreenCell>): Int
 
     /**
+     * Called when the entire scrollback buffer should be cleared.
+     *
+     * @return 0 on success
+     */
+    fun clearScrollback(): Int
+
+    /**
      * Called when keyboard input is generated (user types, terminal generates escape sequences).
      * The caller should write this data to the PTY/transport.
      *
@@ -122,7 +129,7 @@ internal data class TermRect(
     val startRow: Int,
     val endRow: Int,
     val startCol: Int,
-    val endCol: Int
+    val endCol: Int,
 )
 
 /**
@@ -130,7 +137,7 @@ internal data class TermRect(
  */
 internal data class CursorPosition(
     val row: Int,
-    val col: Int
+    val col: Int,
 )
 
 /**
@@ -157,8 +164,10 @@ internal data class ScreenCell(
     val bgBlue: Int,
     val bold: Boolean = false,
     val italic: Boolean = false,
-    val underline: Int = 0,  // 0=none, 1=single, 2=double
+    // 0=none, 1=single, 2=double
+    val underline: Int = 0,
     val reverse: Boolean = false,
     val strike: Boolean = false,
-    val width: Int = 1  // 1 for normal, 2 for fullwidth (CJK)
+    // 1 for normal, 2 for fullwidth (CJK)
+    val width: Int = 1,
 )

--- a/lib/src/main/java/org/connectbot/terminal/TerminalEmulator.kt
+++ b/lib/src/main/java/org/connectbot/terminal/TerminalEmulator.kt
@@ -637,6 +637,19 @@ internal class TerminalEmulatorImpl(
         return 0
     }
 
+    override fun clearScrollback(): Int {
+        synchronized(damageLock) {
+            scrollback.clear()
+            scrollbackDirty = true
+            propertyChanged = true
+            if (!damagePosted) {
+                handler.post { processPendingUpdates() }
+                damagePosted = true
+            }
+        }
+        return 0
+    }
+
     override fun popScrollbackLine(cols: Int, cells: Array<ScreenCell>): Int {
         synchronized(damageLock) {
             if (scrollback.isEmpty()) return 0

--- a/lib/src/test/java/org/connectbot/terminal/ScrollbackClearTest.kt
+++ b/lib/src/test/java/org/connectbot/terminal/ScrollbackClearTest.kt
@@ -1,0 +1,118 @@
+/*
+ * ConnectBot Terminal
+ * Copyright 2026 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.connectbot.terminal
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Tests for ESC[3J (erase saved lines / clear scrollback buffer).
+ *
+ * ESC[3J is the standard xterm sequence to discard the scrollback buffer.
+ * libvterm translates it into a sb_clear callback, which we wire through
+ * to Kotlin via [TerminalCallbacks.clearScrollback].
+ */
+@RunWith(AndroidJUnit4::class)
+class ScrollbackClearTest {
+
+    private fun getSnapshot(impl: TerminalEmulatorImpl): TerminalSnapshot {
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+        impl.processPendingUpdates()
+        return impl.snapshot.value
+    }
+
+    private fun TerminalEmulator.send(s: String) = writeInput(s.toByteArray())
+
+    @Test
+    fun testEsc3JClearsScrollback() = runBlocking {
+        val emulator = TerminalEmulatorFactory.create(initialRows = 5, initialCols = 40)
+        val impl = emulator as TerminalEmulatorImpl
+
+        repeat(10) { emulator.send("line ${it}\r\n") }
+
+        val before = getSnapshot(impl)
+        assertTrue("scrollback must be non-empty before clear", before.scrollback.isNotEmpty())
+
+        emulator.send("\u001B[3J")
+
+        val after = getSnapshot(impl)
+        assertEquals("scrollback must be empty after ESC[3J", 0, after.scrollback.size)
+    }
+
+    @Test
+    fun testEsc3JPreservesVisibleScreen() = runBlocking {
+        val emulator = TerminalEmulatorFactory.create(initialRows = 5, initialCols = 40)
+        val impl = emulator as TerminalEmulatorImpl
+
+        repeat(8) { emulator.send("scrolled ${it}\r\n") }
+        emulator.send("\u001B[1;1H")
+        emulator.send("visible line")
+
+        emulator.send("\u001B[3J")
+
+        val after = getSnapshot(impl)
+        assertEquals("scrollback empty", 0, after.scrollback.size)
+        assertEquals("visible row 0 intact", "visible line", after.lines[0].text.trimEnd())
+    }
+
+    @Test
+    fun testScrollbackRepopulatesAfterClear() = runBlocking {
+        // Clear the visible screen before ESC[3J so the visible "old" rows are blank.
+        // Without this, those rows get pushed into scrollback when the second batch
+        // scrolls them off, making the content check ambiguous.
+        val emulator = TerminalEmulatorFactory.create(initialRows = 5, initialCols = 40)
+        val impl = emulator as TerminalEmulatorImpl
+
+        repeat(8) { emulator.send("old ${it}\r\n") }
+        emulator.send("\u001B[2J\u001B[H") // clear visible screen, cursor home
+        emulator.send("\u001B[3J") // clear scrollback
+
+        val afterClear = getSnapshot(impl)
+        assertEquals("scrollback empty after clear", 0, afterClear.scrollback.size)
+
+        repeat(8) { emulator.send("new ${it}\r\n") }
+
+        val afterNew = getSnapshot(impl)
+        assertTrue("new scrollback lines added", afterNew.scrollback.isNotEmpty())
+        assertTrue(
+            "old lines must not survive the clear",
+            afterNew.scrollback.none { it.text.trimEnd().startsWith("old") },
+        )
+    }
+
+    @Test
+    fun testEsc2JAndEsc3JCombinedClearsEverything() = runBlocking {
+        val emulator = TerminalEmulatorFactory.create(initialRows = 5, initialCols = 40)
+        val impl = emulator as TerminalEmulatorImpl
+
+        repeat(10) { emulator.send("content ${it}\r\n") }
+
+        emulator.send("\u001B[H\u001B[2J\u001B[3J")
+
+        val after = getSnapshot(impl)
+        assertEquals("scrollback empty", 0, after.scrollback.size)
+        assertTrue(
+            "all visible lines blank",
+            after.lines.all { it.text.isBlank() },
+        )
+    }
+}


### PR DESCRIPTION
The terminal emulator can receive codes like \e[3J which should clear scrollback. We previously had not implemented the functionality that libvterm provided. This change hooks up the call to allow this to function correctly.