### PR TITLE
fix #202

### DIFF
--- a/lib/src/main/cpp/Terminal.cpp
+++ b/lib/src/main/cpp/Terminal.cpp
@@ -92,6 +92,10 @@ Terminal::Terminal(JNIEnv* env, jobject callbacks, int rows, int cols)
     if (!mPopScrollbackMethod) {
         LOGE("Failed to find popScrollbackLine method");
     }
+    mClearScrollbackMethod = env->GetMethodID(callbacksClass, "clearScrollback", "()I");
+    if (!mClearScrollbackMethod) {
+        LOGE("Failed to find clearScrollback method");
+    }
     mKeyboardInputMethod = env->GetMethodID(callbacksClass, "onKeyboardInput", "([B)I");
     if (!mKeyboardInputMethod) {
         LOGE("Failed to find onKeyboardInput method");
@@ -198,7 +202,7 @@ Terminal::Terminal(JNIEnv* env, jobject callbacks, int rows, int cols)
         .resize = nullptr,  // We handle resize explicitly
         .sb_pushline = termSbPushline,
         .sb_popline = termSbPopline,
-        .sb_clear = nullptr  // Not needed
+        .sb_clear = termSbClear
     };
     vterm_screen_set_callbacks(mVts, &mScreenCallbacks, this);
 
@@ -573,6 +577,11 @@ int Terminal::termSbPushline(int cols, const VTermScreenCell* cells, void* user)
 int Terminal::termSbPopline(int cols, VTermScreenCell* cells, void* user) {
     auto* term = static_cast<Terminal*>(user);
     return term->invokePopScrollbackLine(cols, cells);
+}
+
+int Terminal::termSbClear(void* user) {
+    auto* term = static_cast<Terminal*>(user);
+    return term->invokeClearScrollback();
 }
 
 void Terminal::termOutput(const char* s, size_t len, void* user) {
@@ -1017,6 +1026,21 @@ int Terminal::invokePopScrollbackLine(int cols, VTermScreenCell* cells) {
     }
 
     return 1;
+}
+
+int Terminal::invokeClearScrollback() {
+    if (!mClearScrollbackMethod) {
+        return 0;
+    }
+
+    JNIEnv* env;
+    if (mJavaVM->GetEnv((void**)&env, JNI_VERSION_1_6) != JNI_OK) {
+        return 0;
+    }
+
+    jint result = env->CallIntMethod(mCallbacks, mClearScrollbackMethod);
+    JNI_CHECK_EXCEPTION_RETURN(env, 0);
+    return result;
 }
 
 void Terminal::invokeKeyboardOutput(const char* data, size_t len) {

--- a/lib/src/main/cpp/Terminal.h
+++ b/lib/src/main/cpp/Terminal.h
@@ -83,6 +83,7 @@ private:
     static int termBell(void* user);
     static int termSbPushline(int cols, const VTermScreenCell* cells, void* user);
     static int termSbPopline(int cols, VTermScreenCell* cells, void* user);
+    static int termSbClear(void* user);
 
     // libvterm output callback (keyboard generates this)
     static void termOutput(const char* s, size_t len, void* user);
@@ -102,6 +103,7 @@ private:
     void invokeBell();
     void invokePushScrollbackLine(int cols, const VTermScreenCell* cells, bool softWrapped);
     int invokePopScrollbackLine(int cols, VTermScreenCell* cells);
+    int invokeClearScrollback();
     void invokeKeyboardOutput(const char* data, size_t len);
     int invokeOscSequence(int command, const std::string& payload, int cursorRow, int cursorCol);
 
@@ -140,6 +142,7 @@ private:
     jmethodID mBellMethod;
     jmethodID mPushScrollbackMethod;
     jmethodID mPopScrollbackMethod;
+    jmethodID mClearScrollbackMethod;
     jmethodID mKeyboardInputMethod;
     jmethodID mOscSequenceMethod;
 

--- a/lib/src/main/java/org/connectbot/terminal/TerminalCallbacks.kt
+++ b/lib/src/main/java/org/connectbot/terminal/TerminalCallbacks.kt
@@ -94,6 +94,13 @@ internal interface TerminalCallbacks {
     fun popScrollbackLine(cols: Int, cells: Array<ScreenCell>): Int
 
     /**
+     * Called when the terminal requests that scrollback history be cleared.
+     *
+     * @return 1 if handled, 0 otherwise
+     */
+    fun clearScrollback(): Int
+
+    /**
      * Called when keyboard input is generated (user types, terminal generates escape sequences).
      * The caller should write this data to the PTY/transport.
      *
@@ -122,7 +129,7 @@ internal data class TermRect(
     val startRow: Int,
     val endRow: Int,
     val startCol: Int,
-    val endCol: Int
+    val endCol: Int,
 )
 
 /**
@@ -130,7 +137,7 @@ internal data class TermRect(
  */
 internal data class CursorPosition(
     val row: Int,
-    val col: Int
+    val col: Int,
 )
 
 /**
@@ -145,6 +152,9 @@ internal sealed class TerminalProperty {
 
 /**
  * A single screen cell with character and attributes.
+ *
+ * @param underline 0=none, 1=single, 2=double
+ * @param width 1 for normal, 2 for fullwidth (CJK)
  */
 internal data class ScreenCell(
     val char: Char,
@@ -157,8 +167,8 @@ internal data class ScreenCell(
     val bgBlue: Int,
     val bold: Boolean = false,
     val italic: Boolean = false,
-    val underline: Int = 0,  // 0=none, 1=single, 2=double
+    val underline: Int = 0,
     val reverse: Boolean = false,
     val strike: Boolean = false,
-    val width: Int = 1  // 1 for normal, 2 for fullwidth (CJK)
+    val width: Int = 1,
 )

--- a/lib/src/main/java/org/connectbot/terminal/TerminalEmulator.kt
+++ b/lib/src/main/java/org/connectbot/terminal/TerminalEmulator.kt
@@ -687,6 +687,21 @@ internal class TerminalEmulatorImpl(
         return 1
     }
 
+    override fun clearScrollback(): Int {
+        synchronized(damageLock) {
+            if (scrollback.isNotEmpty()) {
+                scrollback.clear()
+                scrollbackDirty = true
+            }
+            propertyChanged = true
+            if (!damagePosted) {
+                handler.post { processPendingUpdates() }
+                damagePosted = true
+            }
+        }
+        return 1
+    }
+
     override fun onKeyboardInput(data: ByteArray): Int {
         // Keyboard output callback - post to handler
         handler.post {

--- a/lib/src/main/java/org/connectbot/terminal/TerminalScreenState.kt
+++ b/lib/src/main/java/org/connectbot/terminal/TerminalScreenState.kt
@@ -145,6 +145,7 @@ internal class TerminalScreenState(
      */
     internal fun updateSnapshot(newSnapshot: TerminalSnapshot) {
         snapshot = newSnapshot
+        scrollbackPosition = scrollbackPosition.coerceIn(0, newSnapshot.scrollback.size)
     }
 }
 

--- a/lib/src/test/java/org/connectbot/terminal/CursorAndModeEscapeTest.kt
+++ b/lib/src/test/java/org/connectbot/terminal/CursorAndModeEscapeTest.kt
@@ -205,6 +205,21 @@ class CursorAndModeEscapeTest {
         )
     }
 
+    @Test
+    fun testEraseDisplay3ClearsScrollback() = runBlocking {
+        val emulator = TerminalEmulatorFactory.create(initialRows = 5, initialCols = 40)
+        val impl = emulator as TerminalEmulatorImpl
+
+        repeat(10) { emulator.send("history line $it\r\n") }
+        val before = getSnapshot(impl)
+        assertNotEquals("test setup should create scrollback", 0, before.scrollback.size)
+
+        emulator.send("\u001B[3J")
+
+        val after = getSnapshot(impl)
+        assertEquals("ESC[3J should clear scrollback", 0, after.scrollback.size)
+    }
+
     // -----------------------------------------------------------------------
     // DECSTBM — scroll region (tmux status bar)
     // -----------------------------------------------------------------------


### PR DESCRIPTION
fix #202

- Wire libvterm’s `sb_clear` screen callback through the native `Terminal` JNI bridge
- Clear the Kotlin scrollback buffer when `ESC[3J` is received
- Clamp UI scrollback position after snapshot updates so it cannot point past cleared history
- Add a regression test for `ESC[3J` clearing scrollback