### PR TITLE
chore: switch to std::mutex

### DIFF
--- a/lib/src/main/cpp/Terminal.cpp
+++ b/lib/src/main/cpp/Terminal.cpp
@@ -192,7 +192,10 @@ Terminal::Terminal(JNIEnv* env, jobject callbacks, int rows, int cols)
     mVts = vterm_obtain_screen(mVt);
     vterm_screen_enable_altscreen(mVts, 1);
 
-    // Initialize callback structure as member variable so it doesn't go out of scope
+    // Initialize callback structure as member variable so it doesn't go out of scope.
+    // These callbacks run while mLock may be held by the native entrypoint that
+    // triggered libvterm. Callback implementations must not synchronously call
+    // back into Terminal methods; post/defer work that needs native state.
     mScreenCallbacks = {
         .damage = termDamage,
         .moverect = termMoverect,
@@ -206,7 +209,8 @@ Terminal::Terminal(JNIEnv* env, jobject callbacks, int rows, int cols)
     };
     vterm_screen_set_callbacks(mVts, &mScreenCallbacks, this);
 
-    // Set up OSC fallback handlers for shell integration
+    // Set up OSC fallback handlers for shell integration. These follow the same
+    // no-synchronous-reentry rule as screen callbacks above.
     VTermState* state = vterm_obtain_state(mVt);
     VTermStateFallbacks fallbacks = {
         .control = nullptr,
@@ -220,7 +224,8 @@ Terminal::Terminal(JNIEnv* env, jobject callbacks, int rows, int cols)
     mStateFallbacks = fallbacks;
     vterm_state_set_unrecognised_fallbacks(state, &mStateFallbacks, this);
 
-    // Set up selection callbacks for OSC 52 clipboard support
+    // Set up selection callbacks for OSC 52 clipboard support. These follow the
+    // same no-synchronous-reentry rule as screen callbacks above.
     // Note: libvterm handles base64 decoding internally
     mSelectionCallbacks = {
         .set = termSelectionSet,
@@ -241,7 +246,7 @@ Terminal::Terminal(JNIEnv* env, jobject callbacks, int rows, int cols)
 Terminal::~Terminal() {
     LOGD("Terminal destructor");
 
-    std::lock_guard<std::recursive_mutex> lock(mLock);
+    std::scoped_lock lock(mLock);
 
     if (mVt) {
         vterm_free(mVt);
@@ -274,7 +279,7 @@ Terminal::~Terminal() {
 
 // Input handling - KEY METHOD
 int Terminal::writeInput(const uint8_t* data, size_t length) {
-    std::lock_guard<std::recursive_mutex> lock(mLock);
+    std::scoped_lock lock(mLock);
 
     if (!mVt) {
         LOGE("writeInput: VTerm not initialized");
@@ -292,7 +297,7 @@ int Terminal::writeInput(const uint8_t* data, size_t length) {
 
 // Resize
 int Terminal::resize(int rows, int cols) {
-    std::lock_guard<std::recursive_mutex> lock(mLock);
+    std::scoped_lock lock(mLock);
 
     mRows = rows;
     mCols = cols;
@@ -307,7 +312,7 @@ int Terminal::resize(int rows, int cols) {
 
 // Color configuration
 int Terminal::setPaletteColors(const uint32_t* colors, int count) {
-    std::lock_guard<std::recursive_mutex> lock(mLock);
+    std::scoped_lock lock(mLock);
 
     if (!mVt) {
         LOGE("setPaletteColors: VTerm not initialized");
@@ -339,7 +344,7 @@ int Terminal::setPaletteColors(const uint32_t* colors, int count) {
 }
 
 int Terminal::setBoldHighbright(int enabled) {
-    std::lock_guard<std::recursive_mutex> lock(mLock);
+    std::scoped_lock lock(mLock);
 
     if (!mVt) {
         LOGE("setBoldHighbright: VTerm not initialized");
@@ -357,7 +362,7 @@ int Terminal::setBoldHighbright(int enabled) {
 }
 
 int Terminal::setDefaultColors(uint32_t fgColor, uint32_t bgColor) {
-    std::lock_guard<std::recursive_mutex> lock(mLock);
+    std::scoped_lock lock(mLock);
 
     if (!mVt) {
         LOGE("setDefaultColors: VTerm not initialized");
@@ -391,7 +396,7 @@ int Terminal::setDefaultColors(uint32_t fgColor, uint32_t bgColor) {
 
 // Keyboard input handlers
 bool Terminal::dispatchKey(int modifiers, int key) {
-    std::lock_guard<std::recursive_mutex> lock(mLock);
+    std::scoped_lock lock(mLock);
 
     if (!mVt) {
         return false;
@@ -407,7 +412,7 @@ bool Terminal::dispatchKey(int modifiers, int key) {
 }
 
 bool Terminal::dispatchCharacter(int modifiers, int codepoint) {
-    std::lock_guard<std::recursive_mutex> lock(mLock);
+    std::scoped_lock lock(mLock);
 
     if (!mVt) {
         return false;
@@ -424,7 +429,7 @@ bool Terminal::dispatchCharacter(int modifiers, int codepoint) {
 
 // Cell run retrieval
 int Terminal::getCellRun(JNIEnv* env, int row, int col, jobject runObject) {
-    std::lock_guard<std::recursive_mutex> lock(mLock);
+    std::scoped_lock lock(mLock);
 
     if (!mVts || row < 0 || row >= mRows || col < 0 || col >= mCols) {
         return 0;
@@ -1090,7 +1095,7 @@ int Terminal::invokeOscSequence(int command, const std::string& payload, int cur
 
 // Line info retrieval
 bool Terminal::getLineContinuation(int row) {
-    std::lock_guard<std::recursive_mutex> lock(mLock);
+    std::scoped_lock lock(mLock);
 
     if (!mVt || row < 0 || row >= mRows) {
         return false;

--- a/lib/src/main/cpp/Terminal.h
+++ b/lib/src/main/cpp/Terminal.h
@@ -75,7 +75,8 @@ public:
     int setBoldHighbright(int enabled);
 
 private:
-    // libvterm screen callbacks (called by libvterm)
+    // libvterm screen callbacks (called by libvterm while mLock may be held).
+    // Implementations must not synchronously call back into Terminal methods.
     static int termDamage(VTermRect rect, void* user);
     static int termMoverect(VTermRect dest, VTermRect src, void* user);
     static int termMovecursor(VTermPos pos, VTermPos oldpos, int visible, void* user);
@@ -88,10 +89,12 @@ private:
     // libvterm output callback (keyboard generates this)
     static void termOutput(const char* s, size_t len, void* user);
 
-    // libvterm state fallback for OSC sequences
+    // libvterm state fallback for OSC sequences. Same no-synchronous-reentry
+    // rule as screen callbacks.
     static int termOscFallback(int command, VTermStringFragment frag, void* user);
 
-    // libvterm selection callbacks for OSC 52 clipboard
+    // libvterm selection callbacks for OSC 52 clipboard. Same no-synchronous-
+    // reentry rule as screen callbacks.
     static int termSelectionSet(VTermSelectionMask mask, VTermStringFragment frag, void* user);
     static int termSelectionQuery(VTermSelectionMask mask, void* user);
 
@@ -187,8 +190,10 @@ private:
     jclass mTerminalPropertyColorClass;
     jmethodID mTerminalPropertyColorConstructor;
 
-    // Thread safety (recursive mutex for reentrant calls via callbacks)
-    mutable std::recursive_mutex mLock;
+    // Thread safety. Native entrypoints are serialized by this non-recursive
+    // mutex. Java callbacks invoked from libvterm must not synchronously call
+    // back into Terminal methods; post/defer any work that needs native state.
+    mutable std::mutex mLock;
 };
 
 #endif // TERMSCREEN_TERMINAL_H

--- a/lib/src/main/java/org/connectbot/terminal/TerminalCallbacks.kt
+++ b/lib/src/main/java/org/connectbot/terminal/TerminalCallbacks.kt
@@ -19,8 +19,12 @@ package org.connectbot.terminal
 /**
  * Callbacks invoked by the native terminal layer when terminal state changes.
  *
- * IMPORTANT: Callbacks MUST NOT call back into Terminal methods, as the native
- * mutex is not reentrant. This will cause a deadlock.
+ * IMPORTANT: These callbacks may be invoked while native Terminal state is guarded by
+ * a non-reentrant mutex. Implementations MUST NOT synchronously call back into
+ * TerminalNative or TerminalEmulator methods that enter native code, such as
+ * writeInput(), resize(), dispatchKey(), dispatchCharacter(), getCellRun(), or
+ * getLineContinuation(). Post or otherwise defer that work until after the callback
+ * returns.
  */
 internal interface TerminalCallbacks {
     /**


### PR DESCRIPTION
There is no reentrancy on this mutex (or should not be), so this can safely be switched to std::mutex to eliminate the code smell of using reentrant locks.