### PR TITLE
feat(Terminal): add e-ink friendly rendering options

### DIFF
--- a/lib/api.txt
+++ b/lib/api.txt
@@ -12,6 +12,17 @@ package org.connectbot.terminal {
     property public default int pendingDeadChar;
   }
 
+  public abstract sealed exhaustive class CursorBlinkMode {
+  }
+
+  public static final class CursorBlinkMode.Never extends org.connectbot.terminal.CursorBlinkMode {
+    field public static final org.connectbot.terminal.CursorBlinkMode.Never INSTANCE;
+  }
+
+  public static final class CursorBlinkMode.Terminal extends org.connectbot.terminal.CursorBlinkMode {
+    field public static final org.connectbot.terminal.CursorBlinkMode.Terminal INSTANCE;
+  }
+
   public abstract sealed exhaustive class DelKeyMode {
   }
 
@@ -123,11 +134,11 @@ package org.connectbot.terminal {
   }
 
   public static final class TerminalEmulatorFactory.Companion {
-    method @KotlinOnly public org.connectbot.terminal.TerminalEmulator create(optional android.os.Looper looper, optional int initialRows, optional int initialCols, optional androidx.compose.ui.graphics.Color defaultForeground, optional androidx.compose.ui.graphics.Color defaultBackground, optional kotlin.jvm.functions.Function1<byte[],kotlin.Unit> onKeyboardInput, optional kotlin.jvm.functions.Function0<kotlin.Unit>? onBell, optional kotlin.jvm.functions.Function1<org.connectbot.terminal.TerminalDimensions,kotlin.Unit>? onResize, optional kotlin.jvm.functions.Function1<java.lang.String,kotlin.Unit>? onClipboardCopy, optional kotlin.jvm.functions.Function2<org.connectbot.terminal.ProgressState,java.lang.Integer,kotlin.Unit>? onProgressChange, optional boolean autoDetectUrls, optional boolean boldAsBright);
+    method @KotlinOnly public org.connectbot.terminal.TerminalEmulator create(optional android.os.Looper looper, optional int initialRows, optional int initialCols, optional androidx.compose.ui.graphics.Color defaultForeground, optional androidx.compose.ui.graphics.Color defaultBackground, optional kotlin.jvm.functions.Function1<byte[],kotlin.Unit> onKeyboardInput, optional kotlin.jvm.functions.Function0<kotlin.Unit>? onBell, optional kotlin.jvm.functions.Function1<org.connectbot.terminal.TerminalDimensions,kotlin.Unit>? onResize, optional kotlin.jvm.functions.Function1<java.lang.String,kotlin.Unit>? onClipboardCopy, optional kotlin.jvm.functions.Function2<org.connectbot.terminal.ProgressState,java.lang.Integer,kotlin.Unit>? onProgressChange, optional boolean autoDetectUrls, optional boolean boldAsBright, optional long minUpdateIntervalMs);
   }
 
   public final class TerminalKt {
-    method @KotlinOnly @androidx.compose.runtime.Composable public static void Terminal(org.connectbot.terminal.TerminalEmulator terminalEmulator, optional androidx.compose.ui.Modifier modifier, optional android.graphics.Typeface typeface, optional androidx.compose.ui.unit.TextUnit initialFontSize, optional androidx.compose.ui.unit.TextUnit minFontSize, optional androidx.compose.ui.unit.TextUnit maxFontSize, optional androidx.compose.ui.graphics.Color backgroundColor, optional androidx.compose.ui.graphics.Color foregroundColor, optional androidx.compose.ui.graphics.Color selectionBackgroundColor, optional androidx.compose.ui.graphics.Color selectionForegroundColor, optional boolean keyboardEnabled, optional boolean showSoftKeyboard, optional androidx.compose.ui.focus.FocusRequester focusRequester, optional kotlin.jvm.functions.Function0<kotlin.Unit> onTerminalTap, optional kotlin.jvm.functions.Function1<java.lang.Boolean,kotlin.Unit> onImeVisibilityChanged, optional kotlin.Pair<java.lang.Integer,java.lang.Integer>? forcedSize, optional org.connectbot.terminal.ModifierManager? modifierManager, optional kotlin.jvm.functions.Function1<org.connectbot.terminal.SelectionController,kotlin.Unit>? onSelectionControllerAvailable, optional kotlin.jvm.functions.Function1<java.lang.String,kotlin.Unit> onHyperlinkClick, optional kotlin.jvm.functions.Function1<org.connectbot.terminal.ComposeController,kotlin.Unit>? onComposeControllerAvailable, optional kotlin.jvm.functions.Function0<kotlin.Unit>? onPasteRequest, optional org.connectbot.terminal.RightAltMode rightAltMode, optional org.connectbot.terminal.DelKeyMode delKeyMode, optional kotlin.jvm.functions.Function1<androidx.compose.ui.input.key.KeyEvent,java.lang.Boolean>? onInterceptKey);
+    method @KotlinOnly @androidx.compose.runtime.Composable public static void Terminal(org.connectbot.terminal.TerminalEmulator terminalEmulator, optional androidx.compose.ui.Modifier modifier, optional android.graphics.Typeface typeface, optional androidx.compose.ui.unit.TextUnit initialFontSize, optional androidx.compose.ui.unit.TextUnit minFontSize, optional androidx.compose.ui.unit.TextUnit maxFontSize, optional androidx.compose.ui.graphics.Color backgroundColor, optional androidx.compose.ui.graphics.Color foregroundColor, optional androidx.compose.ui.graphics.Color selectionBackgroundColor, optional androidx.compose.ui.graphics.Color selectionForegroundColor, optional boolean keyboardEnabled, optional boolean showSoftKeyboard, optional androidx.compose.ui.focus.FocusRequester focusRequester, optional kotlin.jvm.functions.Function0<kotlin.Unit> onTerminalTap, optional kotlin.jvm.functions.Function1<java.lang.Boolean,kotlin.Unit> onImeVisibilityChanged, optional kotlin.Pair<java.lang.Integer,java.lang.Integer>? forcedSize, optional org.connectbot.terminal.ModifierManager? modifierManager, optional kotlin.jvm.functions.Function1<org.connectbot.terminal.SelectionController,kotlin.Unit>? onSelectionControllerAvailable, optional kotlin.jvm.functions.Function1<java.lang.String,kotlin.Unit> onHyperlinkClick, optional kotlin.jvm.functions.Function1<org.connectbot.terminal.ComposeController,kotlin.Unit>? onComposeControllerAvailable, optional kotlin.jvm.functions.Function0<kotlin.Unit>? onPasteRequest, optional org.connectbot.terminal.RightAltMode rightAltMode, optional org.connectbot.terminal.DelKeyMode delKeyMode, optional kotlin.jvm.functions.Function1<androidx.compose.ui.input.key.KeyEvent,java.lang.Boolean>? onInterceptKey, optional org.connectbot.terminal.CursorBlinkMode cursorBlinkMode, optional boolean textAntiAlias);
   }
 
   public final class TerminalUrl {
@@ -260,3 +271,4 @@ package org.connectbot.terminal {
   }
 
 }
+

--- a/lib/src/main/java/org/connectbot/terminal/CursorBlinkMode.kt
+++ b/lib/src/main/java/org/connectbot/terminal/CursorBlinkMode.kt
@@ -1,0 +1,35 @@
+/*
+ * ConnectBot Terminal
+ * Copyright 2026 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.connectbot.terminal
+
+/**
+ * Controls whether the cursor blinks.
+ */
+sealed class CursorBlinkMode {
+    /**
+     * Cursor blink follows the terminal program's escape sequences
+     * (DECSCUSR / DEC private mode 12). This is the default.
+     */
+    data object Terminal : CursorBlinkMode()
+
+    /**
+     * Cursor never blinks; it is drawn solid whenever visible, regardless of
+     * what the terminal program requests. Useful on e-ink displays, where a
+     * blinking cursor causes continuous partial refreshes.
+     */
+    data object Never : CursorBlinkMode()
+}

--- a/lib/src/main/java/org/connectbot/terminal/Terminal.kt
+++ b/lib/src/main/java/org/connectbot/terminal/Terminal.kt
@@ -307,6 +307,11 @@ private const val DOUBLE_UNDERLINE_SPACING = 2f
  * @param selectionForegroundColor Foreground color for selected text (default: Black)
  * @param delKeyMode How the backspace/delete keys should map to terminal characters
  * @param onInterceptKey Optional callback to intercept raw Compose KeyEvents before the terminal emulator handles them. Return true to consume the event.
+ * @param cursorBlinkMode Whether the cursor blinks. [CursorBlinkMode.Terminal] (default) follows the
+ *                        terminal program's escape sequences; [CursorBlinkMode.Never] keeps the cursor
+ *                        solid, which avoids continuous partial refreshes on e-ink displays.
+ * @param textAntiAlias Whether terminal text is drawn with anti-aliasing (default: true). Disable for
+ *                      crisp black-and-white glyph edges on e-ink or other 1-bit displays.
  */
 @Composable
 fun Terminal(
@@ -334,6 +339,8 @@ fun Terminal(
     rightAltMode: RightAltMode = RightAltMode.CharacterModifier,
     delKeyMode: DelKeyMode = DelKeyMode.Delete,
     onInterceptKey: ((ComposeKeyEvent) -> Boolean)? = null,
+    cursorBlinkMode: CursorBlinkMode = CursorBlinkMode.Terminal,
+    textAntiAlias: Boolean = true,
 ) {
     if (LocalInspectionMode.current) {
         TerminalPreview(modifier, backgroundColor, foregroundColor)
@@ -366,6 +373,8 @@ fun Terminal(
         selectionBackgroundColor = selectionBackgroundColor,
         selectionForegroundColor = selectionForegroundColor,
         delKeyMode = delKeyMode,
+        cursorBlinkMode = cursorBlinkMode,
+        textAntiAlias = textAntiAlias,
     )
 }
 
@@ -403,6 +412,8 @@ internal fun TerminalWithAccessibility(
     selectionBackgroundColor: Color = Color(0xFFB3D7FF),
     selectionForegroundColor: Color = Color.Black,
     delKeyMode: DelKeyMode = DelKeyMode.Delete,
+    cursorBlinkMode: CursorBlinkMode = CursorBlinkMode.Terminal,
+    textAntiAlias: Boolean = true,
 ) {
     if (terminalEmulator !is TerminalEmulatorImpl) {
         Box(
@@ -524,14 +535,14 @@ internal fun TerminalWithAccessibility(
     }
 
     // Cursor blink animation
-    LaunchedEffect(screenState) {
+    LaunchedEffect(screenState, cursorBlinkMode) {
         snapshotFlow {
             val s = screenState.snapshot
             Triple(s.cursorVisible, s.cursorBlink, s.cursorRow to s.cursorCol)
         }.collectLatest { (visible, blink, _) ->
             if (visible) {
                 cursorBlinkVisible = true
-                if (blink) {
+                if (blink && cursorBlinkMode == CursorBlinkMode.Terminal) {
                     // Show cursor immediately when it moves or becomes visible
                     while (true) {
                         delay(CURSOR_BLINK_RATE_MS)
@@ -545,11 +556,11 @@ internal fun TerminalWithAccessibility(
     }
 
     // Create TextPaint for measuring and drawing (base size)
-    val textPaint = remember(typeface, calculatedFontSize) {
+    val textPaint = remember(typeface, calculatedFontSize, textAntiAlias) {
         TextPaint().apply {
             this.typeface = typeface
             textSize = with(density) { calculatedFontSize.toPx() }
-            isAntiAlias = true
+            isAntiAlias = textAntiAlias
         }
     }
 

--- a/lib/src/main/java/org/connectbot/terminal/TerminalEmulator.kt
+++ b/lib/src/main/java/org/connectbot/terminal/TerminalEmulator.kt
@@ -20,6 +20,7 @@ import android.icu.lang.UCharacter
 import android.icu.lang.UProperty
 import android.os.Handler
 import android.os.Looper
+import android.os.SystemClock
 import android.util.Log
 import android.view.Choreographer
 import androidx.annotation.VisibleForTesting
@@ -220,6 +221,12 @@ class TerminalEmulatorFactory {
          * @param boldAsBright Whether bold text using low-intensity ANSI colors (0–7) promotes to
          *                     the corresponding bright palette color (8–15), matching xterm's
          *                     default boldColors behavior. Defaults to true.
+         * @param minUpdateIntervalMs Minimum interval in milliseconds between snapshot emissions.
+         *                            0 (the default) coalesces updates to display-frame cadence.
+         *                            Larger values batch fast terminal output into fewer, larger
+         *                            redraws — useful on e-ink displays where frequent partial
+         *                            refreshes cause ghosting. Damage is never dropped, only
+         *                            deferred: the final state is always emitted.
          */
         fun create(
             looper: Looper = Looper.getMainLooper(),
@@ -234,6 +241,7 @@ class TerminalEmulatorFactory {
             onProgressChange: ((ProgressState, Int) -> Unit)? = null,
             autoDetectUrls: Boolean = false,
             boldAsBright: Boolean = true,
+            minUpdateIntervalMs: Long = 0L,
         ): TerminalEmulator = TerminalEmulatorImpl(
             looper = looper,
             initialRows = initialRows,
@@ -247,6 +255,7 @@ class TerminalEmulatorFactory {
             onProgressChange = onProgressChange,
             autoDetectUrls = autoDetectUrls,
             boldAsBright = boldAsBright,
+            minUpdateIntervalMs = minUpdateIntervalMs,
         )
     }
 }
@@ -280,6 +289,8 @@ class TerminalEmulatorFactory {
  * @param onResize Optional callback for terminal resize
  * @param onClipboardCopy Optional callback for OSC 52 clipboard copy operations
  * @param onProgressChange Optional callback for OSC 9;4 progress reporting
+ * @param minUpdateIntervalMs Minimum interval in milliseconds between snapshot emissions
+ *                            (0 = display-frame cadence)
  */
 internal class TerminalEmulatorImpl(
     private val looper: Looper = Looper.getMainLooper(),
@@ -294,6 +305,7 @@ internal class TerminalEmulatorImpl(
     private val onProgressChange: ((ProgressState, Int) -> Unit)? = null,
     override val autoDetectUrls: Boolean = false,
     override val boldAsBright: Boolean = true,
+    private val minUpdateIntervalMs: Long = 0L,
 ) : TerminalEmulator,
     TerminalCallbacks {
 
@@ -308,6 +320,11 @@ internal class TerminalEmulatorImpl(
     private val damageLock = Object()
     private val pendingDamageRegions = mutableListOf<DamageRegion>()
     private var damagePosted = false
+
+    // Uptime of the last snapshot emission; guarded by damageLock. Used to
+    // enforce minUpdateIntervalMs between snapshot emissions. Starts one
+    // interval in the past so the first update is never deferred.
+    private var lastUpdateUptimeMs = SystemClock.uptimeMillis() - minUpdateIntervalMs
     private var cursorMoved = false
     private var propertyChanged = false
 
@@ -894,6 +911,9 @@ internal class TerminalEmulatorImpl(
             needsUpdate = damageRegions.isNotEmpty() || cursorMoved || propertyChanged
             cursorMoved = false
             propertyChanged = false
+            if (needsUpdate) {
+                lastUpdateUptimeMs = SystemClock.uptimeMillis()
+            }
         }
 
         if (!needsUpdate) return
@@ -1324,12 +1344,18 @@ internal class TerminalEmulatorImpl(
      * processed. Running updateLine/buildSnapshot for every callback burst can outpace
      * vsync and make Compose redraw the terminal multiple times for one displayed frame.
      *
+     * When minUpdateIntervalMs > 0, snapshot work is instead deferred until at least that
+     * long after the previous emission, batching bursts of output into fewer redraws.
+     *
      * MUST be called with damageLock held.
      */
     private fun requestProcessPendingUpdatesLocked() {
         if (damagePosted) return
         damagePosted = true
-        if (looper == Looper.getMainLooper()) {
+        if (minUpdateIntervalMs > 0L) {
+            val delayMs = lastUpdateUptimeMs + minUpdateIntervalMs - SystemClock.uptimeMillis()
+            handler.postDelayed({ processPendingUpdates() }, delayMs.coerceAtLeast(0L))
+        } else if (looper == Looper.getMainLooper()) {
             handler.post {
                 Choreographer.getInstance().postFrameCallback {
                     processPendingUpdates()

--- a/lib/src/test/java/org/connectbot/terminal/CursorBlinkModeTest.kt
+++ b/lib/src/test/java/org/connectbot/terminal/CursorBlinkModeTest.kt
@@ -1,0 +1,128 @@
+/*
+ * ConnectBot Terminal
+ * Copyright 2026 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.connectbot.terminal
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.view.View
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
+import androidx.compose.ui.unit.dp
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * Tests for the cursorBlinkMode parameter of [Terminal]: with
+ * [CursorBlinkMode.Never] the cursor stays solid even when the terminal
+ * program requests a blinking cursor, so an idle terminal produces no
+ * repaints (important on e-ink displays).
+ *
+ * Blink is observed by capturing the rendered output before and after
+ * advancing the compose clock past the blink half-period.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], qualifiers = "w400dp-h300dp-mdpi")
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+class CursorBlinkModeTest {
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    /** Emulator with some text and an explicitly blink-enabled cursor. */
+    private fun newBlinkingEmulator(): TerminalEmulatorImpl {
+        val emulator = TerminalEmulatorFactory.create(initialRows = 5, initialCols = 20)
+        val impl = emulator as TerminalEmulatorImpl
+        // "CSI ? 12 h" (start cursor blink) plus DECSCUSR "CSI 1 SP q"
+        // (blinking block) — either alone should enable blink.
+        emulator.writeInput("hello\u001B[?12h\u001B[1 q".toByteArray())
+        impl.processPendingUpdates()
+        assertTrue("terminal program requested blink", impl.snapshot.value.cursorBlink)
+        return impl
+    }
+
+    private fun capturePixels(): IntArray {
+        var pixels: IntArray? = null
+        composeTestRule.activityRule.scenario.onActivity { activity ->
+            val content = activity.findViewById<View>(android.R.id.content)
+            val bitmap = Bitmap.createBitmap(content.width, content.height, Bitmap.Config.ARGB_8888)
+            content.draw(Canvas(bitmap))
+            val px = IntArray(bitmap.width * bitmap.height)
+            bitmap.getPixels(px, 0, bitmap.width, 0, 0, bitmap.width, bitmap.height)
+            pixels = px
+        }
+        return pixels!!
+    }
+
+    @Test
+    fun terminalModeBlinksWhenProgramRequestsIt() {
+        val impl = newBlinkingEmulator()
+
+        composeTestRule.mainClock.autoAdvance = false
+        composeTestRule.setContent {
+            Box(Modifier.fillMaxSize().background(Color.Black)) {
+                Terminal(
+                    terminalEmulator = impl,
+                    modifier = Modifier.size(200.dp, 100.dp),
+                    cursorBlinkMode = CursorBlinkMode.Terminal,
+                )
+            }
+        }
+
+        composeTestRule.mainClock.advanceTimeBy(100)
+        val before = capturePixels()
+        // One blink half-period later the cursor has toggled off.
+        composeTestRule.mainClock.advanceTimeBy(500)
+        val after = capturePixels()
+
+        assertFalse("cursor should have blinked", before.contentEquals(after))
+    }
+
+    @Test
+    fun neverModeKeepsCursorSolid() {
+        val impl = newBlinkingEmulator()
+
+        composeTestRule.mainClock.autoAdvance = false
+        composeTestRule.setContent {
+            Box(Modifier.fillMaxSize().background(Color.Black)) {
+                Terminal(
+                    terminalEmulator = impl,
+                    modifier = Modifier.size(200.dp, 100.dp),
+                    cursorBlinkMode = CursorBlinkMode.Never,
+                )
+            }
+        }
+
+        composeTestRule.mainClock.advanceTimeBy(100)
+        val before = capturePixels()
+        // Advance across several would-be blink periods.
+        composeTestRule.mainClock.advanceTimeBy(1600)
+        val after = capturePixels()
+
+        assertTrue("cursor should not blink", before.contentEquals(after))
+    }
+}

--- a/lib/src/test/java/org/connectbot/terminal/SnapshotUpdateIntervalTest.kt
+++ b/lib/src/test/java/org/connectbot/terminal/SnapshotUpdateIntervalTest.kt
@@ -1,0 +1,108 @@
+/*
+ * ConnectBot Terminal
+ * Copyright 2026 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.connectbot.terminal
+
+import android.os.Looper
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Shadows.shadowOf
+import java.time.Duration
+
+/**
+ * Tests for [TerminalEmulatorFactory.create]'s minUpdateIntervalMs parameter,
+ * which throttles snapshot emissions to batch fast output into fewer redraws
+ * (e.g. for e-ink displays).
+ *
+ * These tests exercise the Handler-scheduled update path rather than calling
+ * [TerminalEmulatorImpl.processPendingUpdates] directly, using Robolectric's
+ * paused main looper to control time.
+ */
+@RunWith(AndroidJUnit4::class)
+class SnapshotUpdateIntervalTest {
+
+    private fun screenText(impl: TerminalEmulatorImpl): String = impl.snapshot.value.lines.first().text.trim()
+
+    @Test
+    fun firstUpdateIsNotDeferred() {
+        val emulator = TerminalEmulatorFactory.create(
+            initialRows = 5,
+            initialCols = 20,
+            minUpdateIntervalMs = 250L,
+        )
+        val impl = emulator as TerminalEmulatorImpl
+        val looper = shadowOf(Looper.getMainLooper())
+
+        emulator.writeInput("a".toByteArray())
+        looper.idle()
+
+        assertEquals("a", screenText(impl))
+    }
+
+    @Test
+    fun updatesWithinIntervalAreDeferredAndCoalesced() {
+        val emulator = TerminalEmulatorFactory.create(
+            initialRows = 5,
+            initialCols = 20,
+            minUpdateIntervalMs = 250L,
+        )
+        val impl = emulator as TerminalEmulatorImpl
+        val looper = shadowOf(Looper.getMainLooper())
+
+        // First write emits immediately.
+        emulator.writeInput("a".toByteArray())
+        looper.idle()
+        assertEquals("a", screenText(impl))
+        val seqAfterFirst = impl.snapshot.value.sequenceNumber
+
+        // Writes inside the interval do not emit yet…
+        emulator.writeInput("b".toByteArray())
+        emulator.writeInput("c".toByteArray())
+        looper.idle()
+        assertEquals("still first snapshot", seqAfterFirst, impl.snapshot.value.sequenceNumber)
+        assertEquals("a", screenText(impl))
+
+        // …and once the interval elapses, both coalesce into a single emission.
+        looper.idleFor(Duration.ofMillis(250))
+        assertEquals("one coalesced snapshot", seqAfterFirst + 1, impl.snapshot.value.sequenceNumber)
+        assertEquals("abc", screenText(impl))
+    }
+
+    @Test
+    fun updateAfterIntervalElapsedIsImmediate() {
+        val emulator = TerminalEmulatorFactory.create(
+            initialRows = 5,
+            initialCols = 20,
+            minUpdateIntervalMs = 250L,
+        )
+        val impl = emulator as TerminalEmulatorImpl
+        val looper = shadowOf(Looper.getMainLooper())
+
+        emulator.writeInput("a".toByteArray())
+        looper.idle()
+        assertEquals("a", screenText(impl))
+
+        // Let more than the interval pass with no pending damage.
+        looper.idleFor(Duration.ofMillis(300))
+
+        // A new write is then processed without waiting.
+        emulator.writeInput("b".toByteArray())
+        looper.idle()
+        assertEquals("ab", screenText(impl))
+    }
+}

--- a/lib/src/test/java/org/connectbot/terminal/TextAntiAliasTest.kt
+++ b/lib/src/test/java/org/connectbot/terminal/TextAntiAliasTest.kt
@@ -1,0 +1,120 @@
+/*
+ * ConnectBot Terminal
+ * Copyright 2026 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.connectbot.terminal
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.view.View
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
+import androidx.compose.ui.unit.dp
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * Tests for the textAntiAlias parameter of [Terminal]: with anti-aliasing
+ * disabled, white-on-black text must render using only pure black and pure
+ * white pixels (no gray blend pixels at glyph edges) — the rendering wanted
+ * on e-ink / 1-bit displays.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], qualifiers = "w400dp-h300dp-mdpi")
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+class TextAntiAliasTest {
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    /** Emulator showing text with the cursor hidden (the block cursor draws with alpha). */
+    private fun newEmulator(): TerminalEmulatorImpl {
+        val emulator = TerminalEmulatorFactory.create(initialRows = 5, initialCols = 20)
+        val impl = emulator as TerminalEmulatorImpl
+        // Some glyphs with diagonal strokes, then DECTCEM reset to hide the cursor.
+        emulator.writeInput("WAXY mow\u001B[?25l".toByteArray())
+        impl.processPendingUpdates()
+        assertFalse("cursor should be hidden", impl.snapshot.value.cursorVisible)
+        return impl
+    }
+
+    private fun capturePixels(): IntArray {
+        var pixels: IntArray? = null
+        composeTestRule.activityRule.scenario.onActivity { activity ->
+            val content = activity.findViewById<View>(android.R.id.content)
+            val bitmap = Bitmap.createBitmap(content.width, content.height, Bitmap.Config.ARGB_8888)
+            content.draw(Canvas(bitmap))
+            val px = IntArray(bitmap.width * bitmap.height)
+            bitmap.getPixels(px, 0, bitmap.width, 0, 0, bitmap.width, bitmap.height)
+            pixels = px
+        }
+        return pixels!!
+    }
+
+    @Test
+    fun antiAliasDisabledRendersOnlyPureColors() {
+        val impl = newEmulator()
+
+        composeTestRule.setContent {
+            Box(Modifier.fillMaxSize().background(Color.Black)) {
+                Terminal(
+                    terminalEmulator = impl,
+                    modifier = Modifier.size(200.dp, 100.dp),
+                    textAntiAlias = false,
+                )
+            }
+        }
+        composeTestRule.waitForIdle()
+
+        // Exactly two colors: the background and the glyph color. Any third
+        // color would be an anti-aliased blend pixel at a glyph edge.
+        val colors = capturePixels().distinct().map { "%08X".format(it) }.sorted()
+        assertEquals("expected only background + glyph colors, got $colors", 2, colors.size)
+    }
+
+    @Test
+    fun antiAliasEnabledRendersBlendedEdges() {
+        val impl = newEmulator()
+
+        composeTestRule.setContent {
+            Box(Modifier.fillMaxSize().background(Color.Black)) {
+                Terminal(
+                    terminalEmulator = impl,
+                    modifier = Modifier.size(200.dp, 100.dp),
+                )
+            }
+        }
+        composeTestRule.waitForIdle()
+
+        // Background + glyph color + blend pixels at glyph edges.
+        val colors = capturePixels().distinct()
+        assertTrue(
+            "expected anti-aliased blend pixels at glyph edges, got ${colors.size} colors",
+            colors.size > 2,
+        )
+    }
+}


### PR DESCRIPTION
Three additive options for low-refresh displays such as e-ink panels:

- cursorBlinkMode on Terminal(): CursorBlinkMode.Never keeps the cursor solid even when the terminal program requests blink, so an idle terminal produces no repaints. Default (Terminal) is unchanged.
- textAntiAlias on Terminal(): disable to render glyphs with hard black/white edges for 1-bit displays. Default (true) is unchanged.
- minUpdateIntervalMs on TerminalEmulatorFactory.create(): throttles snapshot emissions so fast output batches into fewer, larger redraws. Damage is only deferred, never dropped. Default (0) keeps the existing display-frame cadence.