### PR TITLE
Expose mouse input dispatch and tracking mode

### DIFF
--- a/lib/src/main/cpp/Terminal.cpp
+++ b/lib/src/main/cpp/Terminal.cpp
@@ -427,6 +427,38 @@ bool Terminal::dispatchCharacter(int modifiers, int codepoint) {
     return true;
 }
 
+bool Terminal::dispatchMouseMove(int row, int col, int modifiers) {
+    std::scoped_lock lock(mLock);
+
+    if (!mVt) {
+        return false;
+    }
+
+    VTermModifier mod = VTERM_MOD_NONE;
+    if (modifiers & 1) mod = (VTermModifier)(mod | VTERM_MOD_SHIFT);
+    if (modifiers & 2) mod = (VTermModifier)(mod | VTERM_MOD_ALT);
+    if (modifiers & 4) mod = (VTermModifier)(mod | VTERM_MOD_CTRL);
+
+    vterm_mouse_move(mVt, row, col, mod);
+    return true;
+}
+
+bool Terminal::dispatchMouseButton(int button, bool pressed, int modifiers) {
+    std::scoped_lock lock(mLock);
+
+    if (!mVt) {
+        return false;
+    }
+
+    VTermModifier mod = VTERM_MOD_NONE;
+    if (modifiers & 1) mod = (VTermModifier)(mod | VTERM_MOD_SHIFT);
+    if (modifiers & 2) mod = (VTermModifier)(mod | VTERM_MOD_ALT);
+    if (modifiers & 4) mod = (VTermModifier)(mod | VTERM_MOD_CTRL);
+
+    vterm_mouse_button(mVt, button, pressed, mod);
+    return true;
+}
+
 // Cell run retrieval
 int Terminal::getCellRun(JNIEnv* env, int row, int col, jobject runObject) {
     std::scoped_lock lock(mLock);
@@ -1222,6 +1254,21 @@ Java_org_connectbot_terminal_TerminalNative_nativeDispatchCharacter(JNIEnv* /* e
                                                                     jlong ptr, jint modifiers, jint character) {
     auto* term = reinterpret_cast<Terminal*>(ptr);
     return term->dispatchCharacter(modifiers, character);
+}
+
+JNIEXPORT jboolean JNICALL
+Java_org_connectbot_terminal_TerminalNative_nativeDispatchMouseMove(JNIEnv* /* env */, jobject /* thiz */,
+                                                                    jlong ptr, jint row, jint col, jint modifiers) {
+    auto* term = reinterpret_cast<Terminal*>(ptr);
+    return term->dispatchMouseMove(row, col, modifiers);
+}
+
+JNIEXPORT jboolean JNICALL
+Java_org_connectbot_terminal_TerminalNative_nativeDispatchMouseButton(JNIEnv* /* env */, jobject /* thiz */,
+                                                                      jlong ptr, jint button, jboolean pressed,
+                                                                      jint modifiers) {
+    auto* term = reinterpret_cast<Terminal*>(ptr);
+    return term->dispatchMouseButton(button, pressed, modifiers);
 }
 
 JNIEXPORT jint JNICALL

--- a/lib/src/main/cpp/Terminal.h
+++ b/lib/src/main/cpp/Terminal.h
@@ -61,6 +61,11 @@ public:
     bool dispatchKey(int modifiers, int key);
     bool dispatchCharacter(int modifiers, int codepoint);
 
+    // Mouse input - generates mouse reports when the host has enabled mouse
+    // tracking. Coordinates are 0-based cell indices.
+    bool dispatchMouseMove(int row, int col, int modifiers);
+    bool dispatchMouseButton(int button, bool pressed, int modifiers);
+
     // Cell data retrieval for rendering
     int getCellRun(JNIEnv* env, int row, int col, jobject runObject);
 

--- a/lib/src/main/java/org/connectbot/terminal/TerminalEmulator.kt
+++ b/lib/src/main/java/org/connectbot/terminal/TerminalEmulator.kt
@@ -69,6 +69,14 @@ sealed class UrlScanScope {
 }
 
 /**
+ * Mouse tracking mode requested by the host program, mirroring libvterm's
+ * VTERM_PROP_MOUSE. [None] means the host is not tracking the mouse and pointer
+ * gestures should be left to the local UI; the other values indicate the host
+ * wants mouse reports (click only, click plus drag, or all motion).
+ */
+enum class MouseTracking { None, Click, Drag, Move }
+
+/**
  * Terminal emulator interface. This has no dependency on any UI framework
  * so it may be run in a Service on Android. It handles the management of
  * the terminal emulation state.
@@ -107,6 +115,30 @@ sealed interface TerminalEmulator {
      * Dispatch a character to the terminal.
      */
     fun dispatchCharacter(modifiers: Int, codepoint: Int)
+
+    /**
+     * Report pointer motion at a 0-based cell position. Only meaningful while
+     * [mouseTracking] is not [MouseTracking.None]; libvterm records the position
+     * and emits a motion report if the active mode reports motion.
+     *
+     * @param modifiers Bitmask: 1=Shift, 2=Alt, 4=Ctrl
+     */
+    fun dispatchMouseMove(row: Int, col: Int, modifiers: Int = 0)
+
+    /**
+     * Report a mouse button change at the current pointer position. Buttons 1-3
+     * are left/middle/right; 4/5 are wheel up/down. Only meaningful while
+     * [mouseTracking] is not [MouseTracking.None].
+     *
+     * @param modifiers Bitmask: 1=Shift, 2=Alt, 4=Ctrl
+     */
+    fun dispatchMouseButton(button: Int, pressed: Boolean, modifiers: Int = 0)
+
+    /**
+     * The mouse tracking mode the host program has requested, as a reactive
+     * stream. [MouseTracking.None] when the host is not tracking the mouse.
+     */
+    val mouseTracking: StateFlow<MouseTracking>
 
     /**
      * Clears the terminal emulator screen.
@@ -322,6 +354,10 @@ internal class TerminalEmulatorImpl(
     )
     internal val snapshot: StateFlow<TerminalSnapshot> = _snapshot.asStateFlow()
 
+    // Mouse tracking mode requested by the host (VTERM_PROP_MOUSE)
+    private val _mouseTracking = MutableStateFlow(MouseTracking.None)
+    override val mouseTracking: StateFlow<MouseTracking> = _mouseTracking.asStateFlow()
+
     // Sequence number for ordering snapshots
     private var sequenceNumber = 0L
 
@@ -446,6 +482,14 @@ internal class TerminalEmulatorImpl(
      */
     override fun dispatchCharacter(modifiers: Int, codepoint: Int) {
         terminalNative.dispatchCharacter(modifiers, codepoint)
+    }
+
+    override fun dispatchMouseMove(row: Int, col: Int, modifiers: Int) {
+        terminalNative.dispatchMouseMove(row, col, modifiers)
+    }
+
+    override fun dispatchMouseButton(button: Int, pressed: Boolean, modifiers: Int) {
+        terminalNative.dispatchMouseButton(button, pressed, modifiers)
     }
 
     /**
@@ -624,6 +668,19 @@ internal class TerminalEmulatorImpl(
                             else -> CursorShape.BLOCK
                         }
                         propertyChanged = true
+                    }
+
+                    // Property 8 is VTERM_PROP_MOUSE (vterm.h VTermProp enum). Values:
+                    // 0 none, 1 click, 2 drag, 3 move (VTERM_PROP_MOUSE_*). This is a
+                    // reactive signal for the UI, not a visual property, so it updates
+                    // its own StateFlow rather than the damage/redraw path.
+                    if (prop == 8) {
+                        _mouseTracking.value = when (value.value) {
+                            1 -> MouseTracking.Click
+                            2 -> MouseTracking.Drag
+                            3 -> MouseTracking.Move
+                            else -> MouseTracking.None
+                        }
                     }
                 }
 

--- a/lib/src/main/java/org/connectbot/terminal/TerminalNative.kt
+++ b/lib/src/main/java/org/connectbot/terminal/TerminalNative.kt
@@ -109,6 +109,34 @@ internal class TerminalNative(callbacks: TerminalCallbacks) : AutoCloseable {
     }
 
     /**
+     * Report pointer motion to the terminal at a 0-based cell position. libvterm
+     * emits a mouse motion report through onKeyboardInput() only when the host has
+     * enabled a tracking mode that reports motion; otherwise it just records the
+     * position for a subsequent button event.
+     *
+     * @param modifiers Bitmask: 1=Shift, 2=Alt, 4=Ctrl
+     * @return true if handled
+     */
+    fun dispatchMouseMove(row: Int, col: Int, modifiers: Int): Boolean {
+        checkNotClosed()
+        return nativeDispatchMouseMove(nativePtr, row, col, modifiers)
+    }
+
+    /**
+     * Report a mouse button change at the current pointer position. Buttons 1-3 are
+     * left/middle/right; 4/5 are wheel up/down (sent as a press). libvterm generates
+     * the correctly encoded report via onKeyboardInput(), or nothing when no mouse
+     * tracking mode is active.
+     *
+     * @param modifiers Bitmask: 1=Shift, 2=Alt, 4=Ctrl
+     * @return true if handled
+     */
+    fun dispatchMouseButton(button: Int, pressed: Boolean, modifiers: Int): Boolean {
+        checkNotClosed()
+        return nativeDispatchMouseButton(nativePtr, button, pressed, modifiers)
+    }
+
+    /**
      * Get a run of cells with identical formatting starting at the given position.
      * This is the primary method for retrieving terminal content for rendering.
      *
@@ -213,6 +241,8 @@ internal class TerminalNative(callbacks: TerminalCallbacks) : AutoCloseable {
     private external fun nativeResize(ptr: Long, rows: Int, cols: Int): Int
     private external fun nativeDispatchKey(ptr: Long, modifiers: Int, key: Int): Boolean
     private external fun nativeDispatchCharacter(ptr: Long, modifiers: Int, character: Int): Boolean
+    private external fun nativeDispatchMouseMove(ptr: Long, row: Int, col: Int, modifiers: Int): Boolean
+    private external fun nativeDispatchMouseButton(ptr: Long, button: Int, pressed: Boolean, modifiers: Int): Boolean
     private external fun nativeGetCellRun(ptr: Long, row: Int, col: Int, run: CellRun): Int
     private external fun nativeSetPaletteColors(ptr: Long, colors: IntArray, count: Int): Int
     private external fun nativeSetDefaultColors(ptr: Long, fgColor: Int, bgColor: Int): Int


### PR DESCRIPTION
Surface libvterm's mouse support through the terminal API:

- Add dispatchMouseMove(row, col) and dispatchMouseButton(button, pressed) to TerminalEmulator, bridged through TerminalNative to vterm_mouse_move/vterm_mouse_button. Coordinates are 0-based cell indices (libvterm adds the wire offset itself); buttons 1-3 are left/middle/right and 4/5 are wheel up/down.
- Expose the host-requested mode as mouseTracking: StateFlow<MouseTracking>, driven by VTERM_PROP_MOUSE, so a UI can tell when the host wants the mouse and otherwise leave gestures to the local UI.

libvterm encodes the reports for the active mode and protocol and emits them through the existing keyboard-input callback, so no new output path is needed.