### PR TITLE
fix(urls): a bare domain must end the token, not prefix a word

### DIFF
--- a/lib/src/main/java/org/connectbot/terminal/TerminalLine.kt
+++ b/lib/src/main/java/org/connectbot/terminal/TerminalLine.kt
@@ -167,9 +167,17 @@ internal data class TerminalLine(
         internal val URL_REGEX = Regex(
             // Scheme URLs: http(s)://... or ftp://...
             """(?:https?://|ftp://)[^\s<>"{}|\\^`\[\]]+""" +
-                // Bare domains with common TLDs, optional :port and /path
+                // Bare domains with common TLDs, optional :port and /path.
+                // `in`, `cc` and `app` are deliberately absent: as file extensions
+                // and package suffixes (`Makefile.in`, `main.cc`, `sh.haven.app`)
+                // they turn up in terminal output far more often than as domains.
                 """|(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?\.)+""" +
-                """(?:com|org|net|edu|gov|io|dev|app|co|uk|de|fr|jp|ru|br|in|au|us|info|biz|me|tv|cc)""" +
+                """(?:com|org|net|edu|gov|io|dev|co|uk|de|fr|jp|ru|br|au|us|info|biz|me|tv)""" +
+                // The TLD has to end the token: no trailing letter/digit/hyphen (else
+                // `nginx.conf` matches `nginx.co`) and no further dotted segment (else
+                // `scipy.io.wavfile` matches `scipy.io`). A trailing `.` with nothing
+                // word-like after it is fine — trimDetectedUrl drops it.
+                """(?![a-zA-Z0-9-]|\.[a-zA-Z0-9])""" +
                 """(?::\d{1,5})?""" +
                 """(?:/[^\s<>"{}|\\^`\[\]]*)?""" +
                 // IP:port (e.g. 192.168.1.1:8080) — require port to avoid matching version numbers

--- a/lib/src/test/java/org/connectbot/terminal/TerminalScreenStateUrlTest.kt
+++ b/lib/src/test/java/org/connectbot/terminal/TerminalScreenStateUrlTest.kt
@@ -249,6 +249,54 @@ class TerminalScreenStateUrlTest {
         assertEquals("connectbot.org/help", state.getHyperlinkUrlAt(0, 10, autoDetectUrls = true))
     }
 
+    /**
+     * The bare-domain branch had no trailing boundary, so it
+     * matched a *prefix* of an ordinary word (`nginx.conf` → `nginx.co`,
+     * `Thread.run(` → `java.lang.Thread.ru`), and its TLD list contained
+     * labels that are far commoner as file extensions than as domains
+     * (`Makefile.in`, `main.cc`). Those cells were underlined and a single
+     * tap launched a browser.
+     */
+    @Test
+    fun filenamesAndDottedIdentifiersAreNotDetectedAsUrls() {
+        val notUrls = listOf(
+            "vi /etc/nginx/nginx.conf", // .co inside .conf
+            "vi /etc/php/8.2/php.ini", // .in inside .ini
+            "cp app.config web.config /srv", // .co inside .config
+            "ls Makefile.in config.h.in", // .in as a real file extension
+            "grep -rn foo src/main.cc", // .cc as a real file extension
+            "ping db.internal", // .in inside .internal
+            "  at java.lang.Thread.run(Thread.java:840)", // .ru inside .run
+            "import scipy.io.wavfile", // .io mid-identifier
+            "sh.haven.app.agent.McpTools", // .app mid-identifier
+        )
+        for (text in notUrls) {
+            val state = screenState(80, text)
+            for (col in text.indices) {
+                assertNull(
+                    "\"$text\" col $col should not be a link",
+                    state.getHyperlinkUrlAt(0, col, autoDetectUrls = true),
+                )
+            }
+        }
+    }
+
+    @Test
+    fun realBareDomainsStillDetectedAfterFilenameGuard() {
+        assertEquals(
+            "google.com",
+            screenState(80, "PING google.com (142.250.187.238) 56 bytes").getHyperlinkUrlAt(0, 6, autoDetectUrls = true),
+        )
+        assertEquals(
+            "example.co.uk",
+            screenState(80, "visit example.co.uk.").getHyperlinkUrlAt(0, 7, autoDetectUrls = true),
+        )
+        assertEquals(
+            "example.com:8080/x",
+            screenState(80, "at example.com:8080/x ok").getHyperlinkUrlAt(0, 4, autoDetectUrls = true),
+        )
+    }
+
     @Test
     fun ipPortUrlIsDetectedInUI() {
         val state = screenState(80, "Connecting to 192.168.1.1:8080/path/to/resource...")


### PR DESCRIPTION
The bare-domain alternative in `TerminalLine.URL_REGEX` has no trailing boundary, so it matches a **prefix** of any word whose dotted tail happens to begin with one of the listed TLDs. Every match is drawn underlined by the auto-detect renderer and is tappable:

| text in the terminal | detected as a link |
| --- | --- |
| `nginx.conf` | `nginx.co` |
| `php.ini` | `php.in` |
| `app.config` | `app.co` |
| `db.internal` | `db.in` |
| `java.lang.Thread.run(Thread.java:840)` | `java.lang.Thread.ru` |
| `scipy.io.wavfile` | `scipy.io` |

Separately, the TLD list contains `in`, `cc` and `app`, which in terminal output are nearly always a file extension or a package suffix rather than a domain — `Makefile.in`, `config.h.in`, `main.cc`, `sh.haven.app`.

The consequences on a touch device are worse than a stray underline: a tap on such a cell opens a browser at an invented address (`https://nginx.co`), and because a hyperlink cell is resolved ahead of the terminal's own tap handling, inside a mouse-mode TUI the cell stops being tappable by the application at all.

**Fix:** require the TLD to end the token — no trailing letter/digit/hyphen (kills `nginx.co` inside `nginx.conf`) and no further dotted segment (kills `scipy.io` inside `scipy.io.wavfile`) — and drop the three colliding TLDs. A trailing `.` with nothing word-like after it still matches, since `trimDetectedUrl` drops it.

Genuine bare domains are unaffected. Pinned by two new tests in `TerminalScreenStateUrlTest`, one asserting that no column of any of those lines resolves to a link, the other that `google.com`, `example.co.uk` and `example.com:8080/x` still do; the existing `bareDomainUrlIsDetectedInUI` (`connectbot.org/help`) is untouched. `:lib:testDebugUnitTest` — 370 tests, 0 failures.

Found downstream in Haven, which vendors termlib: GlassHaven/Haven#385 (a user asking whether the underlines in his terminal were a feature or a bug).
